### PR TITLE
fix - continue reading post JSON null value element observed

### DIFF
--- a/connect-file-pulse-filters/src/main/java/io/streamthoughts/kafka/connect/filepulse/json/DefaultJSONStructConverter.java
+++ b/connect-file-pulse-filters/src/main/java/io/streamthoughts/kafka/connect/filepulse/json/DefaultJSONStructConverter.java
@@ -88,7 +88,8 @@ public class DefaultJSONStructConverter implements JSONStructConverter {
     private static class NullJsonFieldAccessor implements JsonFieldAccessor<Object> {
 
         @Override
-        public TypedValue read(JsonIterator it) {
+        public TypedValue read(JsonIterator it) throws IOException {
+            it.readNull();
             return TypedValue.of(null, Schema.none());
         }
     }

--- a/connect-file-pulse-filters/src/test/java/io/streamthoughts/kafka/connect/filepulse/json/DefaultJSONStructConverterTest.java
+++ b/connect-file-pulse-filters/src/test/java/io/streamthoughts/kafka/connect/filepulse/json/DefaultJSONStructConverterTest.java
@@ -129,16 +129,22 @@ public class DefaultJSONStructConverterTest {
 
     @Test
     public void shouldConvertGivenFieldWithNullValue() throws Exception {
-        TypedValue value = converter.readJson("{\"field-one\" : \"one\", \"field-two\":null}");
+        TypedValue value = converter.readJson("{\"field-one\" : \"one\", \"field-two\":null, \"field-three\":null, \"field-four\":10, \"field-five\":\"five\"}");
         Assert.assertNotNull(value);
         Assert.assertEquals(Type.STRUCT, value.type());
         TypedStruct struct = value.getStruct();
 
         StructSchema schema = struct.schema();
-        assertEquals(2, schema.fields().size());
+        assertEquals(5, schema.fields().size());
         assertNotNull(schema.field("field-one"));
         assertEquals(Type.STRING, schema.field("field-one").schema().type());
         assertNotNull(schema.field("field-two"));
         assertEquals(Type.NULL, schema.field("field-two").schema().type());
+        assertNotNull(schema.field("field-three"));
+        assertEquals(Type.NULL, schema.field("field-three").schema().type());
+        assertNotNull(schema.field("field-four"));
+        assertEquals(Type.LONG, schema.field("field-four").schema().type());
+        assertNotNull(schema.field("field-five"));
+        assertEquals(Type.STRING, schema.field("field-five").schema().type());
     }
 }


### PR DESCRIPTION
Allowing JsonFieldAccessor to read post null value element observed