### PR TITLE
feat(filesystems): add support for AWS S3 (#111)

### DIFF
--- a/connect-file-pulse-api/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/DelegateFileInputIterator.java
+++ b/connect-file-pulse-api/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/DelegateFileInputIterator.java
@@ -100,7 +100,9 @@ public class DelegateFileInputIterator implements FileInputIterator<FileRecord<T
      */
     @Override
     public FileContext context() {
-        checkIsOpen();
+        if (iterator == null) {
+            throw new IllegalStateException("Iterator is not initialized for URI: " + objectURI);
+        }
         return iterator.context();
     }
 

--- a/connect-file-pulse-api/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/FileObjectMeta.java
+++ b/connect-file-pulse-api/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/FileObjectMeta.java
@@ -81,12 +81,18 @@ public interface FileObjectMeta extends Serializable, Comparable<FileObjectMeta>
         ConnectHeaders headers = new ConnectHeaders();
         headers.addString("connect.file.name", name());
         headers.addString("connect.file.uri", uri().toString());
-        headers.addString("connect.file.hash.digest", contentDigest().digest());
-        headers.addString("connect.file.hash.algorithm", contentDigest().algorithm());
         headers.addLong("connect.file.contentLength", contentLength());
         headers.addLong("connect.file.lastModified", lastModified());
-        userDefinedMetadata().forEach( (k, v) -> headers.addString("connect.file." + k, v.toString()));
+        userDefinedMetadata().forEach( (k, v) -> {
+            if (v != null) {
+                headers.addString("connect.file." + k, v.toString());
+            }
+        });
         headers.addString("connect.task.hostname", Network.HOSTNAME);
+        if (contentDigest() != null) {
+            headers.addString("connect.file.hash.digest", contentDigest().digest());
+            headers.addString("connect.file.hash.algorithm", contentDigest().algorithm());
+        }
         return headers;
     }
 

--- a/connect-file-pulse-api/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/GenericFileObjectMeta.java
+++ b/connect-file-pulse-api/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/GenericFileObjectMeta.java
@@ -24,6 +24,7 @@ import com.jsoniter.annotation.JsonProperty;
 import java.net.URI;
 import java.time.Instant;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -74,7 +75,9 @@ public class GenericFileObjectMeta implements FileObjectMeta {
         this.contentLength = contentLength;
         this.lastModified = lastModified;
         this.contentDigest = contentDigest;
-        this.userDefinedMetadata = userDefinedMetadata;
+        this.userDefinedMetadata = userDefinedMetadata == null ?
+            new HashMap<>() :
+            userDefinedMetadata;
     }
 
     public void addUserDefinedMetadata(final String key, final Object value) {
@@ -166,17 +169,17 @@ public class GenericFileObjectMeta implements FileObjectMeta {
         private FileObjectMeta.ContentDigest contentDigest;
         private Map<String, Object> userDefinedMetadata;
 
-        public Builder withUri(URI uri) {
+        public Builder withUri(final URI uri) {
             this.uri = uri;
             return this;
         }
 
-        public Builder withName(String name) {
+        public Builder withName(final String name) {
             this.name = name;
             return this;
         }
 
-        public Builder withContentLength(long contentLength) {
+        public Builder withContentLength(final long contentLength) {
             this.contentLength = contentLength;
             return this;
         }
@@ -189,17 +192,17 @@ public class GenericFileObjectMeta implements FileObjectMeta {
             return this.withLastModified(instant.toEpochMilli());
         }
 
-        public Builder withLastModified(long lastModified) {
+        public Builder withLastModified(final long lastModified) {
             this.lastModified = lastModified;
             return this;
         }
 
-        public Builder withContentDigest(FileObjectMeta.ContentDigest contentDigest) {
+        public Builder withContentDigest(final FileObjectMeta.ContentDigest contentDigest) {
             this.contentDigest = contentDigest;
             return this;
         }
 
-        public Builder withUserDefinedMetadata(Map<String, Object> userDefinedMetadata) {
+        public Builder withUserDefinedMetadata(final Map<String, Object> userDefinedMetadata) {
             this.userDefinedMetadata = userDefinedMetadata;
             return this;
         }

--- a/connect-file-pulse-filesystems/filepulse-amazons3-fs/pom.xml
+++ b/connect-file-pulse-filesystems/filepulse-amazons3-fs/pom.xml
@@ -21,30 +21,24 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>kafka-connect-file-pulse-reactor</artifactId>
         <groupId>io.streamthoughts</groupId>
+        <artifactId>kafka-connect-filepulse-filesystems</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>kafka-connect-filepulse-filesystems</artifactId>
-
-    <packaging>pom</packaging>
-
-    <modules>
-        <module>filepulse-commons-fs</module>
-        <module>filepulse-local-fs</module>
-        <module>filepulse-amazons3-fs</module>
-    </modules>
+    <artifactId>kafka-connect-filepulse-amazons3-fs</artifactId>
+    <description>Kafka Connect FilePulse - FileSystem - Support for Amazon S3</description>
 
     <properties>
-        <checkstyle.config.location>${project.parent.basedir}</checkstyle.config.location>
+        <checkstyle.config.location>${project.parent.basedir}/..</checkstyle.config.location>
+        <aws-java-sdk.version>1.11.952</aws-java-sdk.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>io.streamthoughts</groupId>
-            <artifactId>kafka-connect-file-pulse-api</artifactId>
+            <artifactId>kafka-connect-filepulse-commons-fs</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
@@ -56,13 +50,22 @@
             <artifactId>connect-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-s3</artifactId>
+            <version>${aws-java-sdk.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
         </dependency>
+        <!-- START Test dependencies -->
+        <dependency>
+            <groupId>io.findify</groupId>
+            <artifactId>s3mock_2.11</artifactId>
+            <version>0.2.6</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- END Test dependencies -->
     </dependencies>
 
 </project>

--- a/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/aws/AmazonS3ClientConfig.java
+++ b/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/aws/AmazonS3ClientConfig.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2019-2021 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.kafka.connect.filepulse.storage.aws;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
+import com.amazonaws.regions.Regions;
+import io.streamthoughts.kafka.connect.filepulse.internal.StringUtils;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.types.Password;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * The Amazon S3 client's configuration.
+ */
+public class AmazonS3ClientConfig extends AbstractConfig {
+
+    private static final String GROUP_AWS = "AWS";
+
+    public static final String AWS_ACCESS_KEY_ID_CONFIG = "aws.access.key.id";
+    private static final String AWS_ACCESS_KEY_ID_DOC = "AWS Access Key ID";
+
+    public static final String AWS_SECRET_ACCESS_KEY_CONFIG = "aws.secret.access.key";
+    private static final String AWS_SECRET_ACCESS_KEY_DOC = "AWS Secret Access Key";
+
+    public static final String AWS_SECRET_SESSION_TOKEN_CONFIG = "aws.secret.session.token";
+    private static final String AWS_SECRET_SESSION_TOKEN_DOC = "AWS Secret Session Token";
+
+    public static final String AWS_S3_REGION_CONFIG = "aws.s3.region";
+    private static final String AWS_S3_REGION_DOC = "The AWS S3 Region, e.g. us-east-1";
+    public static final String AWS_S3_REGION_DEFAULT = Regions.DEFAULT_REGION.getName();
+
+    public static final String AWS_S3_PATH_STYLE_ACCESS_ENABLED_CONFIG = "aws.s3.path.style.access.enabled";
+    private static final String AWS_S3_PATH_STYLE_ACCESS_ENABLED_DOC = "Configures the client to use path-style access for all requests.";
+
+    public final static String AWS_S3_BUCKET_NAME_CONFIG = "aws.s3.bucket.name";
+    private final static String AWS_S3_BUCKET_NAME_DOC = "The name of the Amazon S3 bucket.";
+
+    public final static String AWS_S3_BUCKET_PREFIX_CONFIG = "aws.s3.bucket.prefix";
+    private final static String AWS_S3_BUCKET_PREFIX_DOC = "The prefix to be used for restricting the listing of the objects in the bucket";
+
+    public static final String AWS_CREDENTIALS_PROVIDER_CLASS = "aws.credentials.provider.class";
+    private static final String AWS_CREDENTIALS_PROVIDER_DOC = "The AWSCredentialsProvider to use if no access key id and secret access key is configured";
+    public static final String AWS_CREDENTIALS_PROVIDER_DEFAULT = EnvironmentVariableCredentialsProvider.class.getName();
+
+    /**
+     * Creates a new {@link AmazonS3ClientConfig} instance.
+     *
+     * @param originals the original configuration map.
+     */
+    public AmazonS3ClientConfig(final Map<String, ?> originals) {
+        super(getConf(), originals, false);
+    }
+
+    public Password getAwsAccessKeyId() {
+        return getPassword(AWS_ACCESS_KEY_ID_CONFIG);
+    }
+
+    public Password getAwsSecretAccessKey() {
+        return getPassword(AWS_SECRET_ACCESS_KEY_CONFIG);
+    }
+
+    public Password getAwsSecretSessionToken() {
+        return getPassword(AWS_SECRET_SESSION_TOKEN_CONFIG);
+    }
+
+    public String getAwsS3Region() {
+        return getString(AWS_S3_REGION_CONFIG);
+    }
+
+    public String getAwsS3BucketName() {
+        return getString(AWS_S3_BUCKET_NAME_CONFIG);
+    }
+
+    public String getAwsS3BucketPrefix() {
+        return getString(AWS_S3_BUCKET_PREFIX_CONFIG);
+    }
+
+    public boolean isAwsS3PathStyleAccessEnabled() {
+        return getBoolean(AWS_S3_PATH_STYLE_ACCESS_ENABLED_CONFIG);
+    }
+
+    public AWSCredentialsProvider getAwsCredentialsProvider() {
+        return getConfiguredInstance(AWS_CREDENTIALS_PROVIDER_CLASS, AWSCredentialsProvider.class);
+    }
+
+    /**
+     * @return the {@link ConfigDef}.
+     */
+    static ConfigDef getConf() {
+        int awsGroupCounter = 0;
+
+        return new ConfigDef()
+                .define(
+                        AWS_S3_BUCKET_NAME_CONFIG,
+                        ConfigDef.Type.STRING,
+                        ConfigDef.Importance.HIGH,
+                        AWS_S3_BUCKET_NAME_DOC,
+                        GROUP_AWS,
+                        awsGroupCounter++,
+                        ConfigDef.Width.NONE,
+                        AWS_S3_BUCKET_NAME_CONFIG
+                )
+
+                .define(
+                        AWS_S3_BUCKET_PREFIX_CONFIG,
+                        ConfigDef.Type.STRING,
+                        null,
+                        new ConfigDef.NonEmptyString(),
+                        ConfigDef.Importance.MEDIUM,
+                        AWS_S3_BUCKET_PREFIX_DOC,
+                        GROUP_AWS,
+                        awsGroupCounter++,
+                        ConfigDef.Width.NONE,
+                        AWS_S3_BUCKET_NAME_CONFIG
+                )
+
+                .define(
+                        AWS_S3_REGION_CONFIG,
+                        ConfigDef.Type.STRING,
+                        AWS_S3_REGION_DEFAULT,
+                        new AwsRegionValidator(),
+                        ConfigDef.Importance.MEDIUM,
+                        AWS_S3_REGION_DOC,
+                        GROUP_AWS,
+                        awsGroupCounter++,
+                        ConfigDef.Width.NONE,
+                        AWS_S3_REGION_CONFIG
+                )
+
+                .define(
+                        AWS_S3_PATH_STYLE_ACCESS_ENABLED_CONFIG,
+                        ConfigDef.Type.BOOLEAN,
+                        true,
+                        ConfigDef.Importance.MEDIUM,
+                        AWS_S3_PATH_STYLE_ACCESS_ENABLED_DOC,
+                        GROUP_AWS,
+                        awsGroupCounter++,
+                        ConfigDef.Width.NONE,
+                        AWS_S3_PATH_STYLE_ACCESS_ENABLED_CONFIG
+                )
+
+                .define(
+                        AWS_ACCESS_KEY_ID_CONFIG,
+                        ConfigDef.Type.PASSWORD,
+                        new Password(null),
+                        new NonEmptyPassword(),
+                        ConfigDef.Importance.HIGH,
+                        AWS_ACCESS_KEY_ID_DOC,
+                        GROUP_AWS,
+                        awsGroupCounter++,
+                        ConfigDef.Width.NONE,
+                        AWS_ACCESS_KEY_ID_CONFIG
+                )
+
+                .define(
+                        AWS_SECRET_ACCESS_KEY_CONFIG,
+                        ConfigDef.Type.PASSWORD,
+                        null,
+                        new NonEmptyPassword(),
+                        ConfigDef.Importance.HIGH,
+                        AWS_SECRET_ACCESS_KEY_DOC,
+                        GROUP_AWS,
+                        awsGroupCounter++,
+                        ConfigDef.Width.NONE,
+                        AWS_SECRET_ACCESS_KEY_CONFIG
+                )
+
+                .define(
+                        AWS_SECRET_SESSION_TOKEN_CONFIG,
+                        ConfigDef.Type.PASSWORD,
+                        new Password(null),
+                        new NonEmptyPassword(),
+                        ConfigDef.Importance.HIGH,
+                        AWS_SECRET_SESSION_TOKEN_DOC,
+                        GROUP_AWS,
+                        awsGroupCounter++,
+                        ConfigDef.Width.NONE,
+                        AWS_SECRET_SESSION_TOKEN_CONFIG
+                )
+
+                .define(
+                        AWS_CREDENTIALS_PROVIDER_CLASS,
+                        ConfigDef.Type.CLASS,
+                        AWS_CREDENTIALS_PROVIDER_DEFAULT,
+                        ConfigDef.Importance.HIGH,
+                        AWS_CREDENTIALS_PROVIDER_DOC,
+                        GROUP_AWS,
+                        awsGroupCounter++,
+                        ConfigDef.Width.NONE,
+                        AWS_CREDENTIALS_PROVIDER_CLASS
+                );
+    }
+
+    public static class NonEmptyPassword implements ConfigDef.Validator {
+
+        @Override
+        public void ensureValid(final String name, final Object value) {
+            if (Objects.isNull(value) || ((Password) value).value() == null) {
+                return;
+            }
+            final var pwd = (Password) value;
+            if (StringUtils.isBlank(pwd.value())) {
+                throw new ConfigException(name, pwd, "Password must be non-empty");
+            }
+
+        }
+    }
+
+    public static class AwsRegionValidator implements ConfigDef.Validator {
+        private static final String SUPPORTED_AWS_REGIONS =
+                Arrays.stream(Regions.values())
+                        .map(Regions::getName)
+                        .collect(Collectors.joining(", "));
+
+        @Override
+        public void ensureValid(final String name, final Object value) {
+            if (Objects.nonNull(value)) {
+                final String valueStr = (String) value;
+                try {
+                    Regions.fromName(valueStr);
+                } catch (final IllegalArgumentException e) {
+                    throw new ConfigException(
+                            name, valueStr,
+                            "supported values are: " + SUPPORTED_AWS_REGIONS);
+                }
+            }
+        }
+    }
+
+
+}

--- a/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/aws/AmazonS3ClientUtils.java
+++ b/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/aws/AmazonS3ClientUtils.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2019-2021 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.kafka.connect.filepulse.storage.aws;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.PredefinedClientConfigurations;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.BasicSessionCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+import static io.streamthoughts.kafka.connect.filepulse.internal.StringUtils.isNotBlank;
+
+/**
+ * Utility class for creating new {@link AmazonS3} client.
+ */
+public class AmazonS3ClientUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AmazonS3ClientUtils.class);
+
+    /**
+     * Helper method to creates a new {@link AmazonS3} client.
+     *
+     * @param config    The S3 client configurations
+     * @return          a new {@link AmazonS3}.
+     */
+    public static AmazonS3 createS3Client(final AmazonS3ClientConfig config) {
+        return createS3Client(config, null);
+    }
+
+    /**
+     * Helper method to creates a new {@link AmazonS3} client.
+     *
+     * @param config    The S3 client configurations
+     * @param url       The S3 address url.
+     * @return          a new {@link AmazonS3}.
+     */
+    public static AmazonS3 createS3Client(final AmazonS3ClientConfig config,
+                                          final String url) {
+        ClientConfiguration clientConfiguration = PredefinedClientConfigurations.defaultConfig();
+
+        AmazonS3ClientBuilder builder = AmazonS3ClientBuilder.standard()
+                .withPathStyleAccessEnabled(config.isAwsS3PathStyleAccessEnabled())
+                .withCredentials(newCredentialsProvider(config))
+                .withClientConfiguration(clientConfiguration);
+
+        final String region = config.getAwsS3Region();
+        if (isNotBlank(url)) {
+            builder = builder.withEndpointConfiguration(
+                new AwsClientBuilder.EndpointConfiguration(url, region)
+            );
+        } else {
+            builder.withRegion(region);
+        }
+        return builder.build();
+    }
+
+    protected static AWSCredentialsProvider newCredentialsProvider(final AmazonS3ClientConfig config) {
+        final String accessKeyId = config.getAwsAccessKeyId().value();
+        final String secretKey = config.getAwsSecretAccessKey().value();
+        final String sessionToken = config.getAwsSecretSessionToken().value();
+
+        if (isNotBlank(accessKeyId) && isNotBlank(secretKey)) {
+            AWSCredentials credentials;
+            if (isNotBlank(sessionToken)) {
+                LOG.info("Creating new credentials provider using the access key id, "
+                        + "the secret access key and the session token that were passed "
+                        + "through the connector's configuration");
+                credentials = new BasicSessionCredentials(accessKeyId, secretKey, sessionToken);
+            } else {
+                LOG.info("Creating new credentials provider using the access key id and "
+                        + "the secret access key that were passed "
+                        + "through the connector's configuration");
+                credentials = new BasicAWSCredentials(accessKeyId, secretKey);
+            }
+            return new AWSStaticCredentialsProvider(credentials);
+        }
+        LOG.info("Creating new credentials provider using the provider class that was passed "
+                + "through the connector's configuration");
+        return config.getAwsCredentialsProvider();
+    }
+}

--- a/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/aws/S3BucketKey.java
+++ b/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/aws/S3BucketKey.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2019-2021 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.kafka.connect.filepulse.storage.aws;
+
+import com.amazonaws.services.s3.AmazonS3URI;
+
+import java.net.URI;
+import java.util.Objects;
+
+/**
+ * This class represents an object stored in Amazon S3. This object contains
+ * the object key and the Amazon S3 bucket name.
+ */
+public class S3BucketKey {
+
+    private final String bucketName;
+    private final String key;
+
+    /**
+     * An helper method to create a new {@link S3BucketKey} from a given {@link URI}.
+     *
+     * @param uri   the uri.
+     * @return      a new {@link S3BucketKey}.
+     */
+    public static S3BucketKey fromURI(final URI uri) {
+        final AmazonS3URI amazonS3URI = new AmazonS3URI(uri);
+        return new S3BucketKey(
+            amazonS3URI.getBucket(),
+            amazonS3URI.getKey()
+        );
+    }
+
+    /**
+     * Creates a new {@link S3BucketKey} instance.
+     *
+     * @param bucketName    The Amazon S3 bucket name.
+     * @param key           The S3 object key.
+     */
+    public S3BucketKey(final String bucketName, final String key) {
+        this.bucketName = Objects.requireNonNull(bucketName, "bucketName should not be null");
+        this.key = Objects.requireNonNull(key, "key should not be null");;
+    }
+
+    /**
+     * @return the Amazon S3 bucket name.
+     */
+    public String bucketName() {
+        return bucketName;
+    }
+
+    /**
+     * @return the Amazon S3 object key.
+     */
+    public String key() {
+        return key;
+    }
+
+    /**
+     * @return the {@link URI} for this Amazon S3 object.
+     */
+    public URI toURI() {
+        return URI.create("s3://" + bucketName + "/" + key);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof S3BucketKey)) return false;
+        S3BucketKey s3Object = (S3BucketKey) o;
+        return Objects.equals(bucketName, s3Object.bucketName) &&
+                Objects.equals(key, s3Object.key);
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(bucketName, key);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return "S3Object{" +
+                "bucketName='" + bucketName + '\'' +
+                ", key='" + key + '\'' +
+                '}';
+    }
+}

--- a/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/aws/s3/AmazonS3FileSystemListing.java
+++ b/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/aws/s3/AmazonS3FileSystemListing.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2019-2021 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.kafka.connect.filepulse.storage.aws.s3;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ListObjectsRequest;
+import com.amazonaws.services.s3.model.ObjectListing;
+import io.streamthoughts.kafka.connect.filepulse.annotation.VisibleForTesting;
+import io.streamthoughts.kafka.connect.filepulse.fs.FileListFilter;
+import io.streamthoughts.kafka.connect.filepulse.fs.FileSystemListing;
+import io.streamthoughts.kafka.connect.filepulse.source.FileObjectMeta;
+import io.streamthoughts.kafka.connect.filepulse.storage.aws.AmazonS3ClientConfig;
+import io.streamthoughts.kafka.connect.filepulse.storage.aws.AmazonS3ClientUtils;
+import io.streamthoughts.kafka.connect.filepulse.storage.aws.S3BucketKey;
+import org.apache.kafka.common.config.ConfigException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static io.streamthoughts.kafka.connect.filepulse.internal.StringUtils.isNotBlank;
+
+/**
+ * The {@code AmazonS3FileSystemListing} that can be used for listing objects that exist in a specific Amazon S3 bucket.
+ */
+public class AmazonS3FileSystemListing implements FileSystemListing {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AmazonS3FileSystemListing.class);
+
+    private FileListFilter filter;
+    private AmazonS3ClientConfig config;
+    private AmazonS3 client;
+    private AmazonS3Storage s3Storage;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void configure(final Map<String, ?> configs) {
+        configure(new AmazonS3ClientConfig(configs), null);
+    }
+
+    @VisibleForTesting
+    void configure(final AmazonS3ClientConfig config, final String url) {
+        this.config = config;
+        this.client = AmazonS3ClientUtils.createS3Client(config, url);
+        this.s3Storage = new AmazonS3Storage(client);
+        if (!s3Storage.doesS3BucketExist(config.getAwsS3BucketName())) {
+            throw new ConfigException(
+                    "Invalid S3 bucket name. "
+                            + "Bucket does not exist, or an error happens while connecting to Amazon service"
+            );
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Collection<FileObjectMeta> listObjects() {
+        final ListObjectsRequest request = new ListObjectsRequest();
+        request.setBucketName(config.getAwsS3BucketName());
+
+        if (isNotBlank(config.getAwsS3BucketPrefix()))
+            request.setPrefix(config.getAwsS3BucketPrefix());
+
+        final List<FileObjectMeta> objectMetaList = new LinkedList<>();
+        ObjectListing objectListing;
+        try {
+            do {
+                LOG.debug(
+                        "Sending new request for listing objects: bucketName={}, prefix={}",
+                        request.getBucketName(),
+                        request.getPrefix()
+                );
+                objectListing = client.listObjects(request);
+
+                objectMetaList.addAll(objectListing.getObjectSummaries()
+                        .stream()
+                        .map(s3ObjectSummary ->
+                                new S3BucketKey(
+                                        s3ObjectSummary.getBucketName(),
+                                        s3ObjectSummary.getKey()
+                                ))
+                        .map(s3Storage::getObjectMetadata)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList()));
+
+                String marker = objectListing.getNextMarker();
+                if (marker != null) {
+                    LOG.debug("Object listing is truncated, next marker is {}", marker);
+                }
+
+            } while (objectListing.isTruncated());
+        } catch (AmazonServiceException e) {
+            LOG.error(
+                    "Failed to list objects from the Amazon S3 bucket '{}'. "
+                            + "Error occurred while processing the request: {}",
+                    config.getAwsS3BucketName(),
+                    e
+            );
+        } catch (SdkClientException e) {
+            LOG.error(
+                    "Failed to list objects from the Amazon S3 bucket '{}'. "
+                            + "Error occurred while making the request or handling the response: {}",
+                    config.getAwsS3BucketName(),
+                    e
+            );
+        }
+        return filter == null ? objectMetaList : filter.filterFiles(objectMetaList);
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setFilter(final FileListFilter filter) {
+        this.filter = filter;
+    }
+}

--- a/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/aws/s3/AmazonS3Storage.java
+++ b/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/aws/s3/AmazonS3Storage.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2019-2021 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.kafka.connect.filepulse.storage.aws.s3;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3URI;
+import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
+import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import io.streamthoughts.kafka.connect.filepulse.fs.reader.Storage;
+import io.streamthoughts.kafka.connect.filepulse.source.FileObjectMeta;
+import io.streamthoughts.kafka.connect.filepulse.source.GenericFileObjectMeta;
+import io.streamthoughts.kafka.connect.filepulse.storage.aws.S3BucketKey;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Objects;
+
+/**
+ * The {@code AmazonS3Storage} can be used to interact with Amazon S3.
+ */
+public class AmazonS3Storage implements Storage {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AmazonS3Storage.class);
+
+    private final AmazonS3 s3Client;
+
+    /**
+     * Creates a new {@link AmazonS3Storage} instance.
+     *
+     * @param s3Client the Amazon S3 client.
+     */
+    public AmazonS3Storage(final AmazonS3 s3Client) {
+        this.s3Client = Objects.requireNonNull(s3Client, "s3Client should not be null");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean exists(final URI objectURI) {
+        return doesS3ObjectExist(S3BucketKey.fromURI(objectURI));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public InputStream getInputStream(final URI objectURI) {
+        final S3BucketKey s3Object = S3BucketKey.fromURI(objectURI);
+        final GetObjectRequest request = new GetObjectRequest(s3Object.bucketName(), s3Object.key());
+        return s3Client.getObject(request).getObjectContent();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public FileObjectMeta getObjectMetadata(final URI objectURI) {
+        final AmazonS3URI amazonS3URI = new AmazonS3URI(objectURI);
+        return getObjectMetadata(amazonS3URI.getBucket(), amazonS3URI.getKey());
+
+    }
+
+    public FileObjectMeta getObjectMetadata(final String bucketName, final String key) {
+        return getObjectMetadata(new S3BucketKey(bucketName, key));
+    }
+
+    public FileObjectMeta getObjectMetadata(final S3BucketKey s3Object) {
+        var request = new GetObjectMetadataRequest(s3Object.bucketName(), s3Object.key());
+        try {
+            final ObjectMetadata objectMetadata = s3Client.getObjectMetadata(request);
+            return createFileObjectMeta(
+                    s3Object,
+                    objectMetadata
+            );
+        } catch (AmazonServiceException e) {
+            LOG.error(
+                    "Failed to get object metadata from Amazon S3. "
+                            + "Error occurred while processing the request for {}: {}",
+                    s3Object.toURI(),
+                    e
+            );
+            throw e;
+        } catch (SdkClientException e) {
+            LOG.error(
+                    "Failed to get object metadata from Amazon S3. "
+                            + "Error occurred while making the request or handling the response for {}: {}",
+                    s3Object.toURI(),
+                    e
+            );
+            throw e;
+        }
+    }
+
+    public boolean doesS3BucketExist(final String bucketName) {
+        try {
+            return s3Client.doesBucketExistV2(bucketName);
+        } catch (AmazonServiceException e) {
+            LOG.error(
+                    "Failed to check if Amazon S3 bucket '{}' exist. "
+                            + "Error occurred while processing the request: {}",
+                    bucketName,
+                    e
+            );
+        } catch (SdkClientException e) {
+            LOG.error(
+                    "Failed to check if Amazon S3 bucket '{}' exist. "
+                            + "Error occurred while making the request or handling the response: {}",
+                    bucketName,
+                    e
+            );
+        }
+        return false;
+    }
+
+    public boolean doesS3ObjectExist(final S3BucketKey s3Object) {
+        try {
+            return s3Client.doesObjectExist(s3Object.bucketName(), s3Object.key());
+        } catch (AmazonServiceException e) {
+            LOG.error(
+                    "Failed to check if object with key '{}' exist on Amazon S3 bucket '{}'. "
+                            + "Error occurred while processing the request: {}",
+                    s3Object.key(),
+                    s3Object.bucketName(),
+                    e
+            );
+        } catch (SdkClientException e) {
+            LOG.error(
+                    "Failed to check if object with key '{}' exist on Amazon S3 bucket '{}'. "
+                            + "Error occurred while making the request or handling the response: {}",
+                    s3Object.key(),
+                    s3Object.bucketName(),
+                    e
+            );
+        }
+        return false;
+    }
+
+    private static FileObjectMeta createFileObjectMeta(final S3BucketKey s3Object,
+                                                       final ObjectMetadata objectMetadata) {
+
+        final HashMap<String, Object> userDefinedMetadata = new HashMap<>();
+
+        objectMetadata.getUserMetadata().forEach((k, v) -> userDefinedMetadata.put("s3.object.user.metadata." + k, v));
+        userDefinedMetadata.put("s3.object.summary.bucketName", s3Object.bucketName());
+        userDefinedMetadata.put("s3.object.summary.key", s3Object.key());
+        userDefinedMetadata.put("s3.object.summary.etag", objectMetadata.getETag());
+        userDefinedMetadata.put("s3.object.summary.storageClass", objectMetadata.getStorageClass());
+
+        final String contentMD5 = objectMetadata.getContentMD5();
+
+        FileObjectMeta.ContentDigest digest = null;
+        if (contentMD5 != null) {
+            digest = new FileObjectMeta.ContentDigest(contentMD5, "MD5");
+        }
+
+        return new GenericFileObjectMeta.Builder()
+                .withUri(s3Object.toURI())
+                .withName(s3Object.key())
+                .withContentLength(objectMetadata.getContentLength())
+                .withLastModified(objectMetadata.getLastModified())
+                .withContentDigest(digest)
+                .withUserDefinedMetadata(userDefinedMetadata)
+                .build();
+    }
+}

--- a/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/aws/s3/reader/AmazonS3AvroFileInputReader.java
+++ b/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/aws/s3/reader/AmazonS3AvroFileInputReader.java
@@ -16,49 +16,40 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.streamthoughts.kafka.connect.filepulse.fs.reader.text;
+package io.streamthoughts.kafka.connect.filepulse.storage.aws.s3.reader;
 
 import io.streamthoughts.kafka.connect.filepulse.data.TypedStruct;
 import io.streamthoughts.kafka.connect.filepulse.fs.reader.IteratorManager;
-import io.streamthoughts.kafka.connect.filepulse.fs.reader.Storage;
+import io.streamthoughts.kafka.connect.filepulse.fs.reader.avro.AvroDataStreamIterator;
 import io.streamthoughts.kafka.connect.filepulse.reader.FileInputIterator;
-import io.streamthoughts.kafka.connect.filepulse.reader.FileInputIteratorFactory;
 import io.streamthoughts.kafka.connect.filepulse.reader.ReaderException;
+import io.streamthoughts.kafka.connect.filepulse.source.FileObjectMeta;
 import io.streamthoughts.kafka.connect.filepulse.source.FileRecord;
 
 import java.net.URI;
-import java.util.Objects;
 
-public class BytesArrayInputIteratorFactory implements FileInputIteratorFactory {
-
-    private final Storage storage;
-    private final IteratorManager iteratorManager;
-
-    /**
-     * Creates a new {@link BytesArrayInputIteratorFactory} instance.
-     *
-     * @param storage   the {@link Storage}.
-     */
-    public BytesArrayInputIteratorFactory(final Storage storage,
-                                          final IteratorManager iteratorManager) {
-        this.storage = Objects.requireNonNull(storage, "storage should not be null");
-        this.iteratorManager = Objects.requireNonNull(iteratorManager, "iteratorManager should not be null");
-    }
+/**
+ * The {@link AmazonS3AvroFileInputReader} can be used to created records from an AVRO file loaded from Amazon S3.
+ */
+public class AmazonS3AvroFileInputReader extends BaseAmazonS3InputReader {
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public FileInputIterator<FileRecord<TypedStruct>> newIterator(final URI objectURI) {
+    protected FileInputIterator<FileRecord<TypedStruct>> newIterator(final URI objectURI,
+                                                                     final IteratorManager iteratorManager) {
 
         try {
-            return new BytesArrayInputIterator(
-                storage.getObjectMetadata(objectURI),
-                storage.getInputStream(objectURI),
-                iteratorManager
+            final FileObjectMeta metadata = storage().getObjectMetadata(objectURI);
+            return new AvroDataStreamIterator(
+                    metadata,
+                    iteratorManager,
+                    storage().getInputStream(objectURI)
             );
+
         } catch (Exception e) {
-            throw new ReaderException("Failed to create BytesArrayInputIterator for: " + objectURI, e);
+            throw new ReaderException("Failed to create AvroDataStreamIterator for: " + objectURI, e);
         }
     }
 }

--- a/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/aws/s3/reader/AmazonS3BytesArrayInputReader.java
+++ b/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/aws/s3/reader/AmazonS3BytesArrayInputReader.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019-2021 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.kafka.connect.filepulse.storage.aws.s3.reader;
+
+import io.streamthoughts.kafka.connect.filepulse.data.TypedStruct;
+import io.streamthoughts.kafka.connect.filepulse.fs.reader.IteratorManager;
+import io.streamthoughts.kafka.connect.filepulse.fs.reader.text.BytesArrayInputIteratorFactory;
+import io.streamthoughts.kafka.connect.filepulse.reader.FileInputIterator;
+import io.streamthoughts.kafka.connect.filepulse.source.FileRecord;
+
+import java.net.URI;
+import java.util.Map;
+
+public class AmazonS3BytesArrayInputReader extends BaseAmazonS3InputReader {
+
+    private BytesArrayInputIteratorFactory factory;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void configure(final Map<String, ?> configs) {
+        super.configure(configs);
+        this.factory = new BytesArrayInputIteratorFactory(storage(), iteratorManager());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected FileInputIterator<FileRecord<TypedStruct>> newIterator(final URI objectURI,
+                                                                     final IteratorManager iteratorManager) {
+        return factory.newIterator(objectURI);
+    }
+}

--- a/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/aws/s3/reader/AmazonS3FileInputMetadataReader.java
+++ b/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/aws/s3/reader/AmazonS3FileInputMetadataReader.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019-2020 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.streamthoughts.kafka.connect.filepulse.storage.aws.s3.reader;
+
+import io.streamthoughts.kafka.connect.filepulse.data.TypedStruct;
+import io.streamthoughts.kafka.connect.filepulse.fs.reader.FileInputMetadataIteratorFactory;
+import io.streamthoughts.kafka.connect.filepulse.fs.reader.IteratorManager;
+import io.streamthoughts.kafka.connect.filepulse.reader.FileInputIterator;
+import io.streamthoughts.kafka.connect.filepulse.source.FileRecord;
+
+import java.net.URI;
+import java.util.Map;
+
+/**
+ * Send a single record containing file metadata.
+ */
+public class AmazonS3FileInputMetadataReader extends BaseAmazonS3InputReader {
+
+    private FileInputMetadataIteratorFactory factory;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void configure(final Map<String, ?> configs) {
+        super.configure(configs);
+        this.factory = new FileInputMetadataIteratorFactory(storage());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected FileInputIterator<FileRecord<TypedStruct>> newIterator(final URI context,
+                                                                     final IteratorManager iteratorManager) {
+        return factory.newIterator(context);
+    }
+
+}

--- a/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/aws/s3/reader/AmazonS3RowFileInputReader.java
+++ b/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/aws/s3/reader/AmazonS3RowFileInputReader.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019-2021 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.kafka.connect.filepulse.storage.aws.s3.reader;
+
+import io.streamthoughts.kafka.connect.filepulse.data.TypedStruct;
+import io.streamthoughts.kafka.connect.filepulse.fs.reader.text.RowFileInputIteratorFactory;
+import io.streamthoughts.kafka.connect.filepulse.fs.reader.text.RowFileInputIteratorConfig;
+import io.streamthoughts.kafka.connect.filepulse.reader.FileInputIterator;
+import io.streamthoughts.kafka.connect.filepulse.fs.reader.IteratorManager;
+import io.streamthoughts.kafka.connect.filepulse.source.FileRecord;
+
+import java.net.URI;
+import java.util.Map;
+
+public class AmazonS3RowFileInputReader extends BaseAmazonS3InputReader {
+
+    private RowFileInputIteratorFactory factory;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void configure(final Map<String, ?> configs) {
+        super.configure(configs);
+        this.factory = new RowFileInputIteratorFactory(
+            new RowFileInputIteratorConfig(configs),
+            storage(),
+            iteratorManager());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public FileInputIterator<FileRecord<TypedStruct>> newIterator(final URI objectURI,
+                                                                  final IteratorManager iteratorManager) {
+        return factory.newIterator(objectURI);
+    }
+}

--- a/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/aws/s3/reader/AmazonS3XMLFileInputReader.java
+++ b/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/aws/s3/reader/AmazonS3XMLFileInputReader.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019-2021 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.kafka.connect.filepulse.storage.aws.s3.reader;
+
+import io.streamthoughts.kafka.connect.filepulse.data.TypedStruct;
+import io.streamthoughts.kafka.connect.filepulse.fs.reader.xml.XMLFileInputIteratorFactory;
+import io.streamthoughts.kafka.connect.filepulse.fs.reader.xml.XMLFileInputReaderConfig;
+import io.streamthoughts.kafka.connect.filepulse.reader.FileInputIterator;
+import io.streamthoughts.kafka.connect.filepulse.fs.reader.IteratorManager;
+import io.streamthoughts.kafka.connect.filepulse.source.FileRecord;
+
+import java.net.URI;
+import java.util.Map;
+
+/**
+ * The {@link AmazonS3XMLFileInputReader} can be used to created records from an XML file loaded from Amazon S3.
+ */
+public class AmazonS3XMLFileInputReader extends BaseAmazonS3InputReader {
+
+    private XMLFileInputIteratorFactory factory;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void configure(final Map<String, ?> configs) {
+        super.configure(configs);
+        factory = new XMLFileInputIteratorFactory(
+            new XMLFileInputReaderConfig(configs),
+            storage(),
+            iteratorManager()
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected FileInputIterator<FileRecord<TypedStruct>> newIterator(final URI objectURI,
+                                                                     final IteratorManager iteratorManager) {
+        return factory.newIterator(objectURI);
+    }
+}

--- a/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/aws/s3/reader/BaseAmazonS3InputReader.java
+++ b/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/aws/s3/reader/BaseAmazonS3InputReader.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019-2021 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.kafka.connect.filepulse.storage.aws.s3.reader;
+
+import com.amazonaws.services.s3.AmazonS3;
+import io.streamthoughts.kafka.connect.filepulse.annotation.VisibleForTesting;
+import io.streamthoughts.kafka.connect.filepulse.fs.reader.StorageAwareFileInputReader;
+import io.streamthoughts.kafka.connect.filepulse.fs.reader.AbstractFileInputReader;
+import io.streamthoughts.kafka.connect.filepulse.storage.aws.AmazonS3ClientConfig;
+import io.streamthoughts.kafka.connect.filepulse.storage.aws.AmazonS3ClientUtils;
+import io.streamthoughts.kafka.connect.filepulse.storage.aws.s3.AmazonS3Storage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * The {@code BaseAmazonS3InputReader} provides the {@link AmazonS3Storage}.
+ */
+public abstract class BaseAmazonS3InputReader
+        extends AbstractFileInputReader
+        implements StorageAwareFileInputReader<AmazonS3Storage> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BaseAmazonS3InputReader.class);
+
+    private AmazonS3 s3Client;
+    private AmazonS3Storage storage;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void configure(final Map<String, ?> configs) {
+        super.configure(configs);
+        if (storage == null) {
+            LOG.info("Create new Amazon S3 client from the properties passed through the connector's configuration ");
+            final AmazonS3ClientConfig clientConfig = new AmazonS3ClientConfig(configs);
+            s3Client = AmazonS3ClientUtils.createS3Client(clientConfig);
+            storage = new AmazonS3Storage(s3Client);
+        }
+    }
+
+    @VisibleForTesting
+    void setStorage(final AmazonS3Storage storage) {
+        this.storage = storage;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public AmazonS3Storage storage() {
+        return storage;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void close() {
+        if (s3Client != null) {
+            s3Client.shutdown();
+        }
+    }
+}

--- a/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/test/java/io/streamthoughts/kafka/connect/filepulse/storage/aws/s3/AmazonS3FileSystemListingTest.java
+++ b/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/test/java/io/streamthoughts/kafka/connect/filepulse/storage/aws/s3/AmazonS3FileSystemListingTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2019-2021 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.kafka.connect.filepulse.storage.aws.s3;
+
+import io.streamthoughts.kafka.connect.filepulse.source.FileObjectMeta;
+import io.streamthoughts.kafka.connect.filepulse.storage.aws.AmazonS3ClientConfig;
+import org.apache.kafka.common.config.ConfigException;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static io.streamthoughts.kafka.connect.filepulse.storage.aws.AmazonS3ClientConfig.AWS_S3_BUCKET_NAME_CONFIG;
+import static io.streamthoughts.kafka.connect.filepulse.storage.aws.AmazonS3ClientConfig.AWS_S3_BUCKET_PREFIX_CONFIG;
+
+public class AmazonS3FileSystemListingTest extends BaseAmazonS3Test {
+
+    public static final String S3_TEST_BUCKET = "testbucket";
+    public static final List<String> OBJECT_KEYS = Arrays.asList("file/name/foo/1", "file/name/foo/2", "file/name/bar/3");
+
+    @Test
+    public void should_list_all_objects_given_non_empty_bucket() {
+        // GIVEN
+        client.createBucket(S3_TEST_BUCKET);
+        OBJECT_KEYS.forEach(key -> client.putObject(S3_TEST_BUCKET, key, "contents"));
+
+        var clientConfig = new AmazonS3ClientConfig(unmodifiableCommonsProperties);
+        var listing = new AmazonS3FileSystemListing();
+        listing.configure(clientConfig, endpointConfiguration);
+
+        // WHEN
+        final Collection<FileObjectMeta> objects = listing.listObjects();
+
+        // THEN
+        Assert.assertNotNull(objects);
+        Assert.assertEquals(OBJECT_KEYS.size(), objects.size());
+        Assert.assertEquals(OBJECT_KEYS.size(), objects.size());
+
+        final Set<String> onlyNames = objects.stream().map(FileObjectMeta::name).collect(Collectors.toSet());
+        OBJECT_KEYS.forEach(key -> Assert.assertTrue(onlyNames.contains(key)));
+    }
+
+    @Test
+    public void should_list_all_objects_given_non_empty_bucket_and_prefix() {
+        // GIVEN
+        client.createBucket(S3_TEST_BUCKET);
+        OBJECT_KEYS.forEach(key -> client.putObject(S3_TEST_BUCKET, key, "contents"));
+
+        var properties = new HashMap<>(unmodifiableCommonsProperties);
+        properties.put(AWS_S3_BUCKET_PREFIX_CONFIG, "file/name/foo");
+
+        var clientConfig = new AmazonS3ClientConfig(properties);
+        var listing = new AmazonS3FileSystemListing();
+        listing.configure(clientConfig, endpointConfiguration);
+
+        // WHEN
+        final Collection<FileObjectMeta> objects = listing.listObjects();
+
+        // THEN
+        var filteredObjectKeys = OBJECT_KEYS.stream().filter(s -> s.contains("foo")).collect(Collectors.toSet());
+        Assert.assertNotNull(objects);
+        Assert.assertEquals(filteredObjectKeys.size(), objects.size());
+        final Set<String> onlyNames = objects.stream().map(FileObjectMeta::name).collect(Collectors.toSet());
+        filteredObjectKeys.forEach(key -> Assert.assertTrue(onlyNames.contains(key)));
+    }
+
+    @Test(expected = ConfigException.class)
+    public void should_throw_error_given_non_existing_bucket_name() {
+        // GIVEN
+        var properties = new HashMap<>(unmodifiableCommonsProperties);
+        properties.put(AWS_S3_BUCKET_NAME_CONFIG, "dummy");
+        var clientConfig = new AmazonS3ClientConfig(properties);
+
+        var listing = new AmazonS3FileSystemListing();
+
+        // WHEN/THEN
+        listing.configure(clientConfig, endpointConfiguration);
+    }
+}

--- a/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/test/java/io/streamthoughts/kafka/connect/filepulse/storage/aws/s3/BaseAmazonS3Test.java
+++ b/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/test/java/io/streamthoughts/kafka/connect/filepulse/storage/aws/s3/BaseAmazonS3Test.java
@@ -1,0 +1,54 @@
+package io.streamthoughts.kafka.connect.filepulse.storage.aws.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import io.findify.s3mock.S3Mock;
+import io.streamthoughts.kafka.connect.filepulse.storage.aws.AmazonS3ClientConfig;
+import io.streamthoughts.kafka.connect.filepulse.storage.aws.AmazonS3ClientUtils;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+import static io.streamthoughts.kafka.connect.filepulse.storage.aws.AmazonS3ClientConfig.AWS_ACCESS_KEY_ID_CONFIG;
+import static io.streamthoughts.kafka.connect.filepulse.storage.aws.AmazonS3ClientConfig.AWS_S3_BUCKET_NAME_CONFIG;
+import static io.streamthoughts.kafka.connect.filepulse.storage.aws.AmazonS3ClientConfig.AWS_S3_REGION_CONFIG;
+import static io.streamthoughts.kafka.connect.filepulse.storage.aws.AmazonS3ClientConfig.AWS_SECRET_ACCESS_KEY_CONFIG;
+
+public class BaseAmazonS3Test {
+
+    public static final String S3_TEST_BUCKET = "testbucket";
+    protected S3Mock s3Mock;
+    protected AmazonS3 client;
+    protected String endpointConfiguration;
+    protected Map<String, String> unmodifiableCommonsProperties;
+
+    @Before
+    public void setUp() throws Exception {
+        final Random generator = new Random();
+        final int s3Port = generator.nextInt(10000) + 10000;
+        s3Mock = new S3Mock.Builder().withPort(s3Port).withInMemoryBackend().build();
+        s3Mock.start();
+
+        endpointConfiguration = "http://localhost:" + s3Port;
+        unmodifiableCommonsProperties = new HashMap<>();
+        unmodifiableCommonsProperties.put(AWS_ACCESS_KEY_ID_CONFIG, "test_key_id");
+        unmodifiableCommonsProperties.put(AWS_SECRET_ACCESS_KEY_CONFIG, "test_secret_key");
+        unmodifiableCommonsProperties.put(AWS_S3_BUCKET_NAME_CONFIG, S3_TEST_BUCKET);
+        unmodifiableCommonsProperties.put(AWS_S3_REGION_CONFIG, "us-west-2");
+        unmodifiableCommonsProperties = Collections.unmodifiableMap(unmodifiableCommonsProperties);
+
+        client = AmazonS3ClientUtils.createS3Client(
+            new AmazonS3ClientConfig(unmodifiableCommonsProperties),
+            endpointConfiguration
+        );
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        client.shutdown();
+        s3Mock.shutdown();
+    }
+}

--- a/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/test/java/io/streamthoughts/kafka/connect/filepulse/storage/aws/s3/reader/AmazonS3BytesArrayInputReaderTest.java
+++ b/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/test/java/io/streamthoughts/kafka/connect/filepulse/storage/aws/s3/reader/AmazonS3BytesArrayInputReaderTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2019-2021 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.kafka.connect.filepulse.storage.aws.s3.reader;
+
+import io.streamthoughts.kafka.connect.filepulse.data.TypedStruct;
+import io.streamthoughts.kafka.connect.filepulse.reader.FileInputIterator;
+import io.streamthoughts.kafka.connect.filepulse.reader.RecordsIterable;
+import io.streamthoughts.kafka.connect.filepulse.source.FileRecord;
+import io.streamthoughts.kafka.connect.filepulse.source.GenericFileObjectMeta;
+import io.streamthoughts.kafka.connect.filepulse.storage.aws.S3BucketKey;
+import io.streamthoughts.kafka.connect.filepulse.storage.aws.s3.AmazonS3Storage;
+import io.streamthoughts.kafka.connect.filepulse.storage.aws.s3.BaseAmazonS3Test;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.util.Random;
+
+public class AmazonS3BytesArrayInputReaderTest extends BaseAmazonS3Test {
+
+    @Rule
+    public TemporaryFolder testFolder = new TemporaryFolder();
+
+    private byte[] content;
+
+    private File objectFile;
+
+    private AmazonS3BytesArrayInputReader reader;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        objectFile = testFolder.newFile();
+        try(OutputStream os = Files.newOutputStream(objectFile.toPath())) {
+            content = getRandomByteArray();
+            os.write(content);
+            os.flush();
+        }
+        reader = new AmazonS3BytesArrayInputReader();
+        reader.setStorage(new AmazonS3Storage(client));
+        reader.configure(unmodifiableCommonsProperties);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        reader.close();
+    }
+
+    @Test
+    public void should_read_all_bytes_given_s3_object() {
+        client.createBucket(S3_TEST_BUCKET);
+        client.putObject(S3_TEST_BUCKET, "my-key", objectFile);
+
+        final GenericFileObjectMeta meta = new GenericFileObjectMeta.Builder()
+                .withUri(new S3BucketKey(S3_TEST_BUCKET, "my-key").toURI())
+                .build();
+
+        final FileInputIterator<FileRecord<TypedStruct>> iterator = reader.newIterator(meta.uri());
+
+        Assert.assertTrue(iterator.hasNext());
+        final RecordsIterable<FileRecord<TypedStruct>> records = iterator.next();
+
+        Assert.assertEquals(1, records.size());
+        final byte[] actuals = records.last().value().get("message").value();
+        Assert.assertArrayEquals(content, actuals);
+
+    }
+
+    private static byte[] getRandomByteArray() {
+        int byteSize = 1024 * 4;
+        final ByteBuffer bf = ByteBuffer.wrap(new byte[byteSize]);
+        int bufferSize=1024;
+        Random r = new Random();
+        int nbBytes=0;
+        while (nbBytes < byteSize){
+            int nbBytesToWrite = Math.min(byteSize-nbBytes,bufferSize);
+            byte[] bytes = new byte[nbBytesToWrite];
+            r.nextBytes(bytes);
+            bf.put(bytes);
+            nbBytes+=nbBytesToWrite;
+        }
+        return bf.flip().array();
+    }
+
+}

--- a/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/test/java/io/streamthoughts/kafka/connect/filepulse/storage/aws/s3/reader/AmazonS3RowFileInputReaderTest.java
+++ b/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/test/java/io/streamthoughts/kafka/connect/filepulse/storage/aws/s3/reader/AmazonS3RowFileInputReaderTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2019-2021 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.kafka.connect.filepulse.storage.aws.s3.reader;
+
+import io.streamthoughts.kafka.connect.filepulse.data.TypedStruct;
+import io.streamthoughts.kafka.connect.filepulse.reader.FileInputIterator;
+import io.streamthoughts.kafka.connect.filepulse.reader.RecordsIterable;
+import io.streamthoughts.kafka.connect.filepulse.source.FileRecord;
+import io.streamthoughts.kafka.connect.filepulse.source.GenericFileObjectMeta;
+import io.streamthoughts.kafka.connect.filepulse.storage.aws.S3BucketKey;
+import io.streamthoughts.kafka.connect.filepulse.storage.aws.s3.AmazonS3Storage;
+import io.streamthoughts.kafka.connect.filepulse.storage.aws.s3.BaseAmazonS3Test;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+public class AmazonS3RowFileInputReaderTest extends BaseAmazonS3Test {
+
+    private static final String LF = "\n";
+
+    private static final int NLINES = 10;
+
+    @Rule
+    public TemporaryFolder testFolder = new TemporaryFolder();
+
+    private File objectFile;
+
+    private AmazonS3RowFileInputReader reader;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        objectFile = testFolder.newFile();
+        BufferedWriter writer = Files.newBufferedWriter(objectFile.toPath(), Charset.defaultCharset());
+        generateLines(writer);
+
+        reader = new AmazonS3RowFileInputReader();
+        reader.setStorage(new AmazonS3Storage(client));
+        reader.configure(unmodifiableCommonsProperties);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        reader.close();
+    }
+
+    @Test
+    public void should_read_all_lines() {
+        client.createBucket(S3_TEST_BUCKET);
+        client.putObject(S3_TEST_BUCKET, "my-key", objectFile);
+
+        final GenericFileObjectMeta meta = new GenericFileObjectMeta.Builder()
+                .withUri(new S3BucketKey(S3_TEST_BUCKET, "my-key").toURI())
+                .build();
+
+        final FileInputIterator<FileRecord<TypedStruct>> iterator = reader.newIterator(meta.uri());
+        List<FileRecord<TypedStruct>> results = new ArrayList<>();
+        while (iterator.hasNext()) {
+            final RecordsIterable<FileRecord<TypedStruct>> next = iterator.next();
+            results.addAll(next.collect());
+        }
+        Assert.assertEquals(10, results.size());
+    }
+
+    private void generateLines(final BufferedWriter writer) throws IOException {
+
+        for (int i = 0; i < NLINES; i++) {
+            String line = "00000000-" + i;
+            writer.write(line);
+            if (i + 1 < NLINES) {
+                writer.write(LF);
+            }
+        }
+        writer.flush();
+    }
+}

--- a/connect-file-pulse-filesystems/filepulse-commons-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/reader/text/RowFileInputIterator.java
+++ b/connect-file-pulse-filesystems/filepulse-commons-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/reader/text/RowFileInputIterator.java
@@ -49,7 +49,7 @@ public class RowFileInputIterator extends ManagedFileInputIterator<TypedStruct> 
     /**
      * The minimum number of lines to read before returning records.
      */
-    private int minNumReadRecords = 0;
+    private int minNumReadRecords = 1;
 
     private long offsetLines = 0L;
 

--- a/connect-file-pulse-filesystems/filepulse-commons-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/reader/text/internal/ReversedInputFileReader.java
+++ b/connect-file-pulse-filesystems/filepulse-commons-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/reader/text/internal/ReversedInputFileReader.java
@@ -147,7 +147,7 @@ public class ReversedInputFileReader implements AutoCloseable {
                 }
             } while (line != null && records.size() < minRecords);
 
-            // we did'nt find new row after reading fully buffer
+            // we didn't find new row after reading fully buffer
             if (records.isEmpty() && bufferOffset == 0) {
                 final int prevSize = bufferLength();
                 resizeBuffer(bufferLength() * 2);

--- a/connect-file-pulse-filesystems/filepulse-local-fs/src/test/java/io/streamthoughts/kafka/connect/filepulse/fs/reader/LocalRowFileInputReaderTest.java
+++ b/connect-file-pulse-filesystems/filepulse-local-fs/src/test/java/io/streamthoughts/kafka/connect/filepulse/fs/reader/LocalRowFileInputReaderTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2019-2021 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.kafka.connect.filepulse.fs.reader;
+
+import io.streamthoughts.kafka.connect.filepulse.data.TypedStruct;
+import io.streamthoughts.kafka.connect.filepulse.fs.reader.text.internal.TextBlock;
+import io.streamthoughts.kafka.connect.filepulse.reader.FileInputIterator;
+import io.streamthoughts.kafka.connect.filepulse.reader.RecordsIterable;
+import io.streamthoughts.kafka.connect.filepulse.source.FileRecord;
+import io.streamthoughts.kafka.connect.filepulse.source.GenericFileObjectMeta;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+public class LocalRowFileInputReaderTest {
+
+    private static final String LF = "\n";
+
+    private static final int NLINES = 10;
+
+    @Rule
+    public TemporaryFolder testFolder = new TemporaryFolder();
+
+    private File objectFile;
+
+    private LocalRowFileInputReader reader;
+
+    @Before
+    public void setUp() throws Exception {
+        objectFile = testFolder.newFile();
+        BufferedWriter writer = Files.newBufferedWriter(objectFile.toPath(), Charset.defaultCharset());
+        generateLines(writer);
+
+        reader = new LocalRowFileInputReader();
+        reader.configure(new HashMap<>());
+    }
+
+    public void tearDown() {
+        reader.close();
+    }
+
+    @Test
+    public void should_read_all_lines() {
+        final GenericFileObjectMeta meta = new GenericFileObjectMeta.Builder()
+                .withUri(objectFile.toURI())
+                .build();
+
+        final FileInputIterator<FileRecord<TypedStruct>> iterator = reader.newIterator(meta.uri());
+
+        List<FileRecord<TypedStruct>> results = new ArrayList<>();
+        while (iterator.hasNext()) {
+            final RecordsIterable<FileRecord<TypedStruct>> next = iterator.next();
+            results.addAll(next.collect());
+        }
+        Assert.assertEquals(10, results.size());
+    }
+
+    private void generateLines(final BufferedWriter writer) throws IOException {
+
+        for (int i = 0; i < NLINES; i++) {
+            String line = "00000000-" + i;
+            writer.write(line);
+            if (i + 1 < NLINES) {
+                writer.write(LF);
+            }
+        }
+        writer.flush();
+    }
+}

--- a/connect-file-pulse-plugin/pom.xml
+++ b/connect-file-pulse-plugin/pom.xml
@@ -197,81 +197,83 @@
         </profile>
     </profiles>
 
-    <dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>4.5.13</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
+    <dependencies>
         <dependency>
             <groupId>io.streamthoughts</groupId>
             <artifactId>kafka-connect-file-pulse-api</artifactId>
             <version>${project.version}</version>
         </dependency>
-
         <dependency>
             <groupId>io.streamthoughts</groupId>
             <artifactId>kafka-connect-file-pulse-filters</artifactId>
             <version>${project.version}</version>
         </dependency>
-
         <dependency>
             <groupId>io.streamthoughts</groupId>
             <artifactId>kafka-connect-filepulse-local-fs</artifactId>
             <version>${project.version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>io.streamthoughts</groupId>
+            <artifactId>kafka-connect-filepulse-amazons3-fs</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>
             <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
+
 
         <!-- START test dependencies-->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
-
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-schema-registry-client</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
         </dependency>
-
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
         </dependency>
-
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>json-path</artifactId>
         </dependency>
-
         <!-- END test dependencies-->
-
     </dependencies>
 
 </project>


### PR DESCRIPTION
This commit adds the new module filepulse-amazons3-fs that provides:
- AmazonS3AvroFileInputReader
- AmazonS3BytesArrayInputReader
- AmazonS3RowFileInputReader
- AmazonS3XMLFileInputReader
- AmazonS3FileSystemListing