### PR TITLE
feat(filesystems): add support for Google Cloud Storage (#121)

### DIFF
--- a/connect-file-pulse-filesystems/filepulse-commons-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/reader/text/NonBlockingBufferReader.java
+++ b/connect-file-pulse-filesystems/filepulse-commons-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/reader/text/NonBlockingBufferReader.java
@@ -33,7 +33,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 /**
- * A BufferedReader wrapper to read lines in non-blocking way.
+ * A {@link BufferedReader} wrapper to read lines in non-blocking way.
  */
 public class NonBlockingBufferReader implements AutoCloseable {
 
@@ -134,12 +134,12 @@ public class NonBlockingBufferReader implements AutoCloseable {
         // Instead we have to manage splitting lines ourselves, using simple backoff when no new value
         // is available.
         final List<TextBlock> records = new LinkedList<>();
-        // Number of bytes read during last iteration.
-        int nread = 0;
 
         boolean maxNumRecordsNotReached = true;
 
-        while ( !(isEOF = !reader.ready() || nread == -1) &&
+        // Number of bytes read during last iteration.
+        int nread = 0;
+        while ( !(isEOF = nread == -1) &&
                 (records.isEmpty() || records.size() < minRecords)
         ) {
             nread = reader.read(buffer, bufferOffset, buffer.length - bufferOffset);
@@ -211,8 +211,7 @@ public class NonBlockingBufferReader implements AutoCloseable {
 
     public boolean hasNext() {
         try {
-            boolean ready = reader.ready();
-            if (ready && (!isEOF || stream.available() > 1)) return true;
+            if (!isEOF || stream.available() > 1) return true;
             return remaining() && containsLine();
         } catch (IOException e) {
             LOG.error("Error while checking for remaining bytes to read: {}", e.getLocalizedMessage());

--- a/connect-file-pulse-filesystems/filepulse-google-cloud-storage-fs/pom.xml
+++ b/connect-file-pulse-filesystems/filepulse-google-cloud-storage-fs/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.streamthoughts</groupId>
+        <artifactId>kafka-connect-filepulse-filesystems</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>kafka-connect-filepulse-google-cloud-storage-fs</artifactId>
+
+    <description>Kafka Connect FilePulse - FileSystem - Support for Google Cloud Storage</description>
+
+    <properties>
+        <checkstyle.config.location>${project.parent.basedir}/..</checkstyle.config.location>
+    </properties>
+
+    <dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>libraries-bom</artifactId>
+      <version>19.2.1</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+  </dependencies>
+</dependencyManagement>
+
+    <dependencies>
+	      <dependency>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>google-cloud-storage</artifactId>
+  </dependency>
+        <dependency>
+            <groupId>io.streamthoughts</groupId>
+            <artifactId>kafka-connect-filepulse-commons-fs</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-nio</artifactId>
+            <version>0.122.11</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/connect-file-pulse-filesystems/filepulse-google-cloud-storage-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/gcp/GcsClientConfig.java
+++ b/connect-file-pulse-filesystems/filepulse-google-cloud-storage-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/gcp/GcsClientConfig.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2021 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.kafka.connect.filepulse.storage.gcp;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.types.Password;
+
+import java.util.Map;
+
+/**
+ * The Google Cloud Storage client's configuration.
+ */
+public class GcsClientConfig extends AbstractConfig {
+
+    private static final String GROUP_GCS = "GCS";
+
+    public static final String GCS_CREDENTIALS_PATH_CONFIG = "gcs.credentials.path";
+
+    public static final String GCS_CREDENTIALS_JSON_CONFIG = "gcs.credentials.json";
+
+    private static final String GCS_CREDENTIALS_JSON_DOC = "The GCP credentials as JSON string. "
+            + "Cannot be set when \"" + GCS_CREDENTIALS_PATH_CONFIG + "\" is provided. "
+            + "If no credentials is specified the client library will look for credentials via "
+            + "the environment variable GOOGLE_APPLICATION_CREDENTIALS.";
+
+    private static final String GCS_CREDENTIALS_PATH_DOC = "The path to GCP credentials file. "
+            + "Cannot be set when \"" + GCS_CREDENTIALS_JSON_CONFIG + "\" is provided. "
+            + "If no credentials is specified the client library will look for credentials via "
+            + "the environment variable GOOGLE_APPLICATION_CREDENTIALS.";
+
+    public static final String GCS_BUCKET_NAME_CONFIG = "gcs.bucket.name";
+    private static final String GCS_BUCKET_NAME_DOC = "The GCS bucket name to download the object files from.";
+
+    public static final String GCS_BLOBS_FILTER_PREFIX_CONFIG = "gcs.blobs.filter.prefix";
+    public static final String GCS_BLOBS_FILTER_PREFIX_DOC = "The prefix to be used for filtering blobs "
+            + "whose names begin with it.";
+
+    /**
+     * Creates a new {@link GcsClientConfig} instance.
+     *
+     * @param originals the original configuration map.
+     */
+    public GcsClientConfig(final Map<?, ?> originals) {
+        super(configDef(), originals, false);
+        validate();
+    }
+
+    private void validate() {
+        final Password credentialsJson = getCredentialsJson();
+        final String credentialsPath = getCredentialsPath();
+
+        if (credentialsPath != null && credentialsJson != null) {
+            throw new ConfigException(String.format(
+                    "\"%s\" and \"%s\" are mutually exclusive options, but both are set.",
+                    GCS_CREDENTIALS_PATH_CONFIG,
+                    GCS_CREDENTIALS_JSON_CONFIG)
+            );
+        }
+    }
+
+    public static ConfigDef configDef() {
+        int gscGroupCounter = 0;
+
+        return new ConfigDef()
+                .define(
+                        GCS_CREDENTIALS_PATH_CONFIG,
+                        ConfigDef.Type.STRING,
+                        null,
+                        ConfigDef.Importance.HIGH,
+                        GCS_CREDENTIALS_PATH_DOC,
+                        GROUP_GCS,
+                        gscGroupCounter++,
+                        ConfigDef.Width.NONE,
+                        GCS_CREDENTIALS_PATH_CONFIG
+                )
+
+                .define(
+                        GCS_CREDENTIALS_JSON_CONFIG,
+                        ConfigDef.Type.PASSWORD,
+                        null,
+                        ConfigDef.Importance.HIGH,
+                        GCS_CREDENTIALS_JSON_DOC,
+                        GROUP_GCS,
+                        gscGroupCounter++,
+                        ConfigDef.Width.NONE,
+                        GCS_CREDENTIALS_JSON_CONFIG
+                )
+
+                .define(
+                        GCS_BUCKET_NAME_CONFIG,
+                        ConfigDef.Type.STRING,
+                        ConfigDef.NO_DEFAULT_VALUE,
+                        new ConfigDef.NonEmptyString(),
+                        ConfigDef.Importance.HIGH,
+                        GCS_BUCKET_NAME_DOC,
+                        GROUP_GCS,
+                        gscGroupCounter++,
+                        ConfigDef.Width.NONE,
+                        GCS_BUCKET_NAME_CONFIG
+                )
+
+                .define(
+                        GCS_BLOBS_FILTER_PREFIX_CONFIG,
+                        ConfigDef.Type.STRING,
+                        null,
+                        ConfigDef.Importance.MEDIUM,
+                        GCS_BLOBS_FILTER_PREFIX_DOC,
+                        GROUP_GCS,
+                        gscGroupCounter++,
+                        ConfigDef.Width.NONE,
+                        GCS_BLOBS_FILTER_PREFIX_CONFIG
+                );
+    }
+
+    public final String getBlobsPrefix() {
+        return getString(GCS_BLOBS_FILTER_PREFIX_CONFIG);
+    }
+
+    public final String getCredentialsPath() {
+        return getString(GCS_CREDENTIALS_PATH_CONFIG);
+    }
+
+    public final Password getCredentialsJson() {
+        return getPassword(GCS_CREDENTIALS_JSON_CONFIG);
+    }
+
+    public final String getBucketName() {
+        return getString(GCS_BUCKET_NAME_CONFIG);
+    }
+}

--- a/connect-file-pulse-filesystems/filepulse-google-cloud-storage-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/gcp/GcsClientUtils.java
+++ b/connect-file-pulse-filesystems/filepulse-google-cloud-storage-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/gcp/GcsClientUtils.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2021 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.kafka.connect.filepulse.storage.gcp;
+
+import com.google.auth.Credentials;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.types.Password;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * The {@code GcsAuthenticationUtils} can be used to build a new {@link Storage} instance from a
+ * {@link GcsClientConfig} object.
+ */
+public class GcsClientUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GcsClientUtils.class);
+
+    /**
+     * Helper method to creates a new {@link Storage} object.
+     *
+     * @param config The Google Cloud Storage configurations
+     * @return a new {@link Storage}.
+     */
+    public static Storage createStorageService(final GcsClientConfig config) {
+        final String credentialsPath = config.getCredentialsPath();
+        final Password credentialsJsonPwd = config.getCredentialsJson();
+        try {
+            String credentialsJson = null;
+            if (credentialsJsonPwd != null) {
+                credentialsJson = credentialsJsonPwd.value();
+            }
+
+            if (credentialsPath != null && credentialsJson != null) {
+                throw new IllegalArgumentException("Both credentialsPath and credentialsJson cannot be non-null.");
+            }
+
+            if (credentialsPath != null) {
+                LOG.info("Creating new Google Cloud Storage service using the "
+                        + "the credentials file that was passed "
+                        + "through the connector's configuration");
+                return getStorageServiceForCredentials(
+                        getCredentialsFromPath(credentialsPath)
+                );
+            }
+
+            if (credentialsJson != null) {
+                LOG.info("Creating new Google Cloud Storage service using the "
+                        + "the credentials JSON that was passed "
+                        + "through the connector's configuration");
+                return getStorageServiceForCredentials(
+                        getCredentialsFromJson(credentialsJson)
+                );
+            }
+
+            LOG.info("No credentials were passed through the connector's configuration." +
+                    " Use default Google Cloud Storage service");
+        } catch (final Exception e) {
+            throw new ConfigException(
+                    "Failed to Google Cloud Storage service using the connector's configuration",
+                    e
+            );
+        }
+
+        return StorageOptions.getDefaultInstance().getService();
+    }
+
+    private static Storage getStorageServiceForCredentials(final Credentials credentials) {
+        return StorageOptions.newBuilder().setCredentials(credentials).build().getService();
+    }
+
+    private static GoogleCredentials getCredentialsFromPath(final String credentialsPath) throws IOException {
+        try (final InputStream stream = new FileInputStream(credentialsPath)) {
+            return GoogleCredentials.fromStream(stream);
+        } catch (final IOException e) {
+            LOG.error("Failed to read credentials from JSON string", e);
+            throw e;
+        }
+    }
+
+    private static GoogleCredentials getCredentialsFromJson(final String credentialsJson) throws IOException {
+        try (final InputStream stream = new ByteArrayInputStream(credentialsJson.getBytes())) {
+            return GoogleCredentials.fromStream(stream);
+        } catch (final IOException e) {
+            LOG.error("Failed to read credentials from JSON string", e);
+            throw e;
+        }
+    }
+}

--- a/connect-file-pulse-filesystems/filepulse-google-cloud-storage-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/gcp/GcsFileSystemListing.java
+++ b/connect-file-pulse-filesystems/filepulse-google-cloud-storage-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/gcp/GcsFileSystemListing.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2021 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.kafka.connect.filepulse.storage.gcp;
+
+import com.google.api.gax.paging.Page;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageException;
+import io.streamthoughts.kafka.connect.filepulse.fs.FileListFilter;
+import io.streamthoughts.kafka.connect.filepulse.fs.FileSystemListing;
+import io.streamthoughts.kafka.connect.filepulse.source.FileObjectMeta;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+public class GcsFileSystemListing implements FileSystemListing {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GcsFileSystemListing.class);
+
+    private GcsClientConfig config;
+
+    private Storage gcsClient;
+
+    private FileListFilter filter;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void configure(final Map<String, ?> configs) {
+        config = new GcsClientConfig(configs);
+        gcsClient = GcsClientUtils.createStorageService(config);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Collection<FileObjectMeta> listObjects() {
+
+        final String blobsPrefix = config.getBlobsPrefix();
+        final String bucketName = config.getBucketName();
+
+        final List<FileObjectMeta> objectMetaList = new LinkedList<>();
+        try {
+            final Page<Blob> blobs;
+            if (blobsPrefix != null) {
+                LOG.info(
+                        "Listing the blobs in the bucket '{}' whose names begin with prefix '{}'",
+                        bucketName,
+                        blobsPrefix
+                );
+                blobs = gcsClient.list(bucketName, Storage.BlobListOption.prefix(blobsPrefix));
+            } else {
+                LOG.info(
+                        "Listing the blobs in the bucket '{}'",
+                        bucketName
+                );
+                blobs = gcsClient.list(bucketName);
+            }
+            for (Blob blob : blobs.iterateAll()) {
+                if (isBlobMustBeIgnored(blob)) {
+                    LOG.info("Ignored blob in bucket '{}' with name '{}' (is_directory={}, size={})",
+                            blob.getBucket(),
+                            blob.getName(),
+                            blob.isDirectory(),
+                            blob.getSize()
+                    );
+                } else{
+                    objectMetaList.add(GcsStorage.createFileObjectMeta(blob));
+                }
+            }
+        } catch (StorageException e) {
+            LOG.error(
+                    "Failed to list blobs from the Google Cloud Storage bucket '{}'. ",
+                    config.getBucketName(),
+                    e
+            );
+        }
+
+        return filter == null ? objectMetaList : filter.filterFiles(objectMetaList);
+    }
+
+    private boolean isBlobMustBeIgnored(final Blob blob) {
+        return blob.isDirectory()
+                || blob.getName().endsWith("/")
+                || blob.getSize() == 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setFilter(final FileListFilter filter) {
+        this.filter = filter;
+    }
+}

--- a/connect-file-pulse-filesystems/filepulse-google-cloud-storage-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/gcp/GcsStorage.java
+++ b/connect-file-pulse-filesystems/filepulse-google-cloud-storage-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/gcp/GcsStorage.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2021 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.kafka.connect.filepulse.storage.gcp;
+
+import com.google.cloud.ReadChannel;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.StorageException;
+import io.streamthoughts.kafka.connect.filepulse.annotation.VisibleForTesting;
+import io.streamthoughts.kafka.connect.filepulse.errors.ConnectFilePulseException;
+import io.streamthoughts.kafka.connect.filepulse.fs.reader.Storage;
+import io.streamthoughts.kafka.connect.filepulse.source.FileObjectMeta;
+import io.streamthoughts.kafka.connect.filepulse.source.GenericFileObjectMeta;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.channels.Channels;
+import java.util.HashMap;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A {@link Storage} implementation for Google Cloud Storage.
+ */
+public class GcsStorage implements Storage {
+
+    public static final String GCS_URI_SCHEME = "gcs://";
+    public static final String URI_SEPARATOR = "/";
+    private final com.google.cloud.storage.Storage storage;
+
+    /**
+     * Creates a new {@link GcsStorage} instance.
+     * @param storage   the {@link com.google.cloud.storage.Storage} storage.
+     */
+    public GcsStorage(final com.google.cloud.storage.Storage storage) {
+        this.storage = storage;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public FileObjectMeta getObjectMetadata(final URI uri) {
+        try {
+            return createFileObjectMeta(getBlob(uri));
+        } catch (IOException e) {
+            throw new ConnectFilePulseException("Failed to get Blob metadata for uri: " + uri, e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean exists(final URI uri) {
+        try {
+            return existsBlob(getBlob(uri));
+        } catch (IOException e) {
+            throw new ConnectFilePulseException("Failed to check if Blob exists for uri: " + uri, e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public InputStream getInputStream(final URI uri) {
+        final Blob blob;
+        try {
+            blob = getBlob(uri);
+        } catch (IOException e) {
+            throw new ConnectFilePulseException("Failed to get Blob for uri: " + uri, e);
+        }
+        ReadChannel channel = blob.reader();
+        return Channels.newInputStream(channel);
+    }
+
+    @VisibleForTesting
+    Blob getBlob(final URI uri) throws IOException {
+        try {
+            final String path = getBase(uri).relativize(uri).getPath();
+            return storage.get(BlobId.of(uri.getHost(), path));
+        } catch (StorageException e) {
+            throw new IOException(e);
+        }
+    }
+
+    private URI getBase(final URI uri) throws IOException {
+        try {
+            return new URI(uri.getScheme(), uri.getHost(), null, null);
+        } catch (URISyntaxException e) {
+            throw new IOException(e);
+        }
+    }
+
+    private boolean existsBlob(final Blob blob) {
+        return blob != null && blob.exists();
+    }
+
+    public static FileObjectMeta createFileObjectMeta(final Blob blob) {
+
+        final HashMap<String, Object> userDefinedMetadata = new HashMap<>();
+
+        userDefinedMetadata.put("gcs.blob.bucket", blob.getBucket());
+        userDefinedMetadata.put("gcs.blob.name", blob.getName());
+
+        Optional.ofNullable(blob.getMetadata())
+                .ifPresent(it -> it.forEach((k, v) -> userDefinedMetadata.put("gcs.blob.user.metadata." + k, v)));
+        Optional.ofNullable(blob.getEtag())
+                .ifPresent(it -> userDefinedMetadata.put("gcs.blob.etag", it));
+        Optional.ofNullable(blob.getStorageClass())
+                .ifPresent(it -> userDefinedMetadata.put("gcs.blob.storageClass", it.name()));
+        Optional.ofNullable(blob.getContentEncoding())
+                .ifPresent(it -> userDefinedMetadata.put("gcs.blob.contentEncoding", it));
+        Optional.ofNullable(blob.getContentType())
+                .ifPresent(it -> userDefinedMetadata.put("gcs.blob.contentType", it));
+        Optional.ofNullable(blob.getCreateTime())
+                .ifPresent(it -> userDefinedMetadata.put("gcs.blob.createTime", it));
+        Optional.ofNullable(blob.getOwner())
+                .ifPresent(it -> userDefinedMetadata.put("gcs.blob.ownerType", it.getType()));
+
+        return new GenericFileObjectMeta.Builder()
+                .withUri(createBlobURI(blob))
+                .withName(blob.getName())
+                .withContentLength(blob.getSize())
+                .withLastModified(blob.getUpdateTime())
+                .withContentDigest(getContentDigestOrNull(blob))
+                .withUserDefinedMetadata(userDefinedMetadata)
+                .build();
+    }
+
+    private static URI createBlobURI(final Blob blob) {
+        Objects.requireNonNull(blob, "blob should not be null");
+        return createBlobURI(blob.getBucket(), blob.getName());
+    }
+
+    public static URI createBlobURI(final String bucketName,
+                                    final String name) {
+        return URI.create(GCS_URI_SCHEME + bucketName + URI_SEPARATOR + name);
+    }
+
+    private static FileObjectMeta.ContentDigest getContentDigestOrNull(final Blob blob) {
+        final String crc32c = blob.getCrc32c();
+        final String md5 = blob.getMd5();
+        if (crc32c != null)
+            return new FileObjectMeta.ContentDigest(crc32c, "CRC32");
+        else if (md5 != null)
+            return new FileObjectMeta.ContentDigest(md5, "MD5");
+
+        return null;
+    }
+}

--- a/connect-file-pulse-filesystems/filepulse-google-cloud-storage-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/gcp/reader/BaseGcsInputReader.java
+++ b/connect-file-pulse-filesystems/filepulse-google-cloud-storage-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/gcp/reader/BaseGcsInputReader.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.kafka.connect.filepulse.storage.gcp.reader;
+
+import com.google.cloud.storage.Storage;
+import io.streamthoughts.kafka.connect.filepulse.annotation.VisibleForTesting;
+import io.streamthoughts.kafka.connect.filepulse.fs.reader.AbstractFileInputReader;
+import io.streamthoughts.kafka.connect.filepulse.fs.reader.StorageAwareFileInputReader;
+import io.streamthoughts.kafka.connect.filepulse.storage.gcp.GcsClientConfig;
+import io.streamthoughts.kafka.connect.filepulse.storage.gcp.GcsClientUtils;
+import io.streamthoughts.kafka.connect.filepulse.storage.gcp.GcsStorage;
+
+import java.util.Map;
+
+/**
+ * The {@code BaseGcsInputReader} provides the {@link GcsStorage}.
+ */
+public abstract class BaseGcsInputReader extends AbstractFileInputReader
+        implements StorageAwareFileInputReader<GcsStorage> {
+
+    private GcsStorage storage;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void configure(final Map<String, ?> configs) {
+        super.configure(configs);
+        if (storage == null) {
+            final GcsClientConfig clientConfig = new GcsClientConfig(configs);
+            final Storage gcsClient = GcsClientUtils.createStorageService(clientConfig);
+            storage = new GcsStorage(gcsClient);
+        }
+    }
+
+    @VisibleForTesting
+    void setStorage(final GcsStorage storage) {
+        this.storage = storage;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GcsStorage storage() {
+        return storage;
+    }
+}

--- a/connect-file-pulse-filesystems/filepulse-google-cloud-storage-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/gcp/reader/GcsAvroFileInputReader.java
+++ b/connect-file-pulse-filesystems/filepulse-google-cloud-storage-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/gcp/reader/GcsAvroFileInputReader.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019-2021 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.kafka.connect.filepulse.storage.gcp.reader;
+
+import io.streamthoughts.kafka.connect.filepulse.data.TypedStruct;
+import io.streamthoughts.kafka.connect.filepulse.fs.reader.IteratorManager;
+import io.streamthoughts.kafka.connect.filepulse.fs.reader.avro.AvroDataStreamIterator;
+import io.streamthoughts.kafka.connect.filepulse.reader.FileInputIterator;
+import io.streamthoughts.kafka.connect.filepulse.reader.ReaderException;
+import io.streamthoughts.kafka.connect.filepulse.source.FileObjectMeta;
+import io.streamthoughts.kafka.connect.filepulse.source.FileRecord;
+
+import java.net.URI;
+
+/**
+ * The {@code GcsAvroFileInputReader} can be used for creating records
+ * from an AVRO file loaded from Google Cloud Storage.
+ */
+public class GcsAvroFileInputReader extends BaseGcsInputReader {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected FileInputIterator<FileRecord<TypedStruct>> newIterator(final URI objectURI,
+                                                                     final IteratorManager iteratorManager) {
+
+        try {
+            final FileObjectMeta metadata = storage().getObjectMetadata(objectURI);
+            return new AvroDataStreamIterator(
+                    metadata,
+                    iteratorManager,
+                    storage().getInputStream(objectURI)
+            );
+
+        } catch (Exception e) {
+            throw new ReaderException("Failed to create AvroDataStreamIterator for: " + objectURI, e);
+        }
+    }
+}

--- a/connect-file-pulse-filesystems/filepulse-google-cloud-storage-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/gcp/reader/GcsBytesArrayInputReader.java
+++ b/connect-file-pulse-filesystems/filepulse-google-cloud-storage-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/gcp/reader/GcsBytesArrayInputReader.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019-2021 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.kafka.connect.filepulse.storage.gcp.reader;
+
+import io.streamthoughts.kafka.connect.filepulse.data.TypedStruct;
+import io.streamthoughts.kafka.connect.filepulse.fs.reader.IteratorManager;
+import io.streamthoughts.kafka.connect.filepulse.fs.reader.text.BytesArrayInputIteratorFactory;
+import io.streamthoughts.kafka.connect.filepulse.reader.FileInputIterator;
+import io.streamthoughts.kafka.connect.filepulse.source.FileRecord;
+
+import java.net.URI;
+import java.util.Map;
+
+/**
+ * The {@code GcsBytesArrayInputReader} can be used for creating record
+ * from an object file loaded from Google Cloud Storage.
+ */
+public class GcsBytesArrayInputReader extends BaseGcsInputReader {
+
+    private BytesArrayInputIteratorFactory factory;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void configure(final Map<String, ?> configs) {
+        super.configure(configs);
+        this.factory = new BytesArrayInputIteratorFactory(storage(), iteratorManager());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected FileInputIterator<FileRecord<TypedStruct>> newIterator(final URI objectURI,
+                                                                     final IteratorManager iteratorManager) {
+        return factory.newIterator(objectURI);
+    }
+}

--- a/connect-file-pulse-filesystems/filepulse-google-cloud-storage-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/gcp/reader/GcsFileInputMetadataReader.java
+++ b/connect-file-pulse-filesystems/filepulse-google-cloud-storage-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/gcp/reader/GcsFileInputMetadataReader.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019-2020 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.streamthoughts.kafka.connect.filepulse.storage.gcp.reader;
+
+import io.streamthoughts.kafka.connect.filepulse.data.TypedStruct;
+import io.streamthoughts.kafka.connect.filepulse.fs.reader.FileInputMetadataIteratorFactory;
+import io.streamthoughts.kafka.connect.filepulse.fs.reader.IteratorManager;
+import io.streamthoughts.kafka.connect.filepulse.reader.FileInputIterator;
+import io.streamthoughts.kafka.connect.filepulse.source.FileRecord;
+
+import java.net.URI;
+import java.util.Map;
+
+/**
+ * Send a single record containing file metadata.
+ */
+public class GcsFileInputMetadataReader extends BaseGcsInputReader {
+
+    private FileInputMetadataIteratorFactory factory;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void configure(final Map<String, ?> configs) {
+        super.configure(configs);
+        this.factory = new FileInputMetadataIteratorFactory(storage());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected FileInputIterator<FileRecord<TypedStruct>> newIterator(final URI context,
+                                                                     final IteratorManager iteratorManager) {
+        return factory.newIterator(context);
+    }
+
+}

--- a/connect-file-pulse-filesystems/filepulse-google-cloud-storage-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/gcp/reader/GcsRowFileInputReader.java
+++ b/connect-file-pulse-filesystems/filepulse-google-cloud-storage-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/gcp/reader/GcsRowFileInputReader.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019-2021 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.kafka.connect.filepulse.storage.gcp.reader;
+
+import io.streamthoughts.kafka.connect.filepulse.data.TypedStruct;
+import io.streamthoughts.kafka.connect.filepulse.fs.reader.IteratorManager;
+import io.streamthoughts.kafka.connect.filepulse.fs.reader.text.RowFileInputIteratorConfig;
+import io.streamthoughts.kafka.connect.filepulse.fs.reader.text.RowFileInputIteratorFactory;
+import io.streamthoughts.kafka.connect.filepulse.reader.FileInputIterator;
+import io.streamthoughts.kafka.connect.filepulse.source.FileRecord;
+
+import java.net.URI;
+import java.util.Map;
+
+/**
+ * The {@code GcsRowFileInputReader} can be used for creating record
+ * from an row-oriented file loaded from Google Cloud Storage.
+ */
+public class GcsRowFileInputReader extends BaseGcsInputReader {
+
+    private RowFileInputIteratorFactory factory;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void configure(final Map<String, ?> configs) {
+        super.configure(configs);
+        this.factory = new RowFileInputIteratorFactory(
+            new RowFileInputIteratorConfig(configs),
+            storage(),
+            iteratorManager());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public FileInputIterator<FileRecord<TypedStruct>> newIterator(final URI objectURI,
+                                                                  final IteratorManager iteratorManager) {
+        return factory.newIterator(objectURI);
+    }
+}

--- a/connect-file-pulse-filesystems/filepulse-google-cloud-storage-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/gcp/reader/GcsXMLFileInputReader.java
+++ b/connect-file-pulse-filesystems/filepulse-google-cloud-storage-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/gcp/reader/GcsXMLFileInputReader.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019-2021 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.kafka.connect.filepulse.storage.gcp.reader;
+
+import io.streamthoughts.kafka.connect.filepulse.data.TypedStruct;
+import io.streamthoughts.kafka.connect.filepulse.fs.reader.IteratorManager;
+import io.streamthoughts.kafka.connect.filepulse.fs.reader.xml.XMLFileInputIteratorFactory;
+import io.streamthoughts.kafka.connect.filepulse.fs.reader.xml.XMLFileInputReaderConfig;
+import io.streamthoughts.kafka.connect.filepulse.reader.FileInputIterator;
+import io.streamthoughts.kafka.connect.filepulse.source.FileRecord;
+
+import java.net.URI;
+import java.util.Map;
+
+/**
+ * The {@code GcsXMLFileInputReader} can be used for creating records
+ * from an XML object file loaded from Google Cloud Storage.
+ */
+public class GcsXMLFileInputReader extends BaseGcsInputReader {
+
+    private XMLFileInputIteratorFactory factory;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void configure(final Map<String, ?> configs) {
+        super.configure(configs);
+        factory = new XMLFileInputIteratorFactory(
+            new XMLFileInputReaderConfig(configs),
+            storage(),
+            iteratorManager()
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected FileInputIterator<FileRecord<TypedStruct>> newIterator(final URI objectURI,
+                                                                     final IteratorManager iteratorManager) {
+        return factory.newIterator(objectURI);
+    }
+}

--- a/connect-file-pulse-filesystems/filepulse-google-cloud-storage-fs/src/test/java/io/streamthoughts/kafka/connect/filepulse/storage/gcp/GcsClientConfigTest.java
+++ b/connect-file-pulse-filesystems/filepulse-google-cloud-storage-fs/src/test/java/io/streamthoughts/kafka/connect/filepulse/storage/gcp/GcsClientConfigTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.kafka.connect.filepulse.storage.gcp;
+
+import org.apache.kafka.common.config.ConfigException;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class GcsClientConfigTest {
+
+    @Test
+    public void should_get_config_given_bucket_name() {
+        final GcsClientConfig config = new GcsClientConfig(Map.of(
+                GcsClientConfig.GCS_BUCKET_NAME_CONFIG, "test-bucket",
+                GcsClientConfig.GCS_BLOBS_FILTER_PREFIX_CONFIG, "prefix"
+        ));
+        Assert.assertEquals("test-bucket", config.getBucketName());
+        Assert.assertEquals("prefix", config.getBlobsPrefix());
+    }
+
+    @Test(expected = ConfigException.class)
+    public void should_throw_exception_when_bucket_is_missing() {
+        new GcsClientConfig(Collections.emptyMap());
+    }
+
+    @Test(expected = ConfigException.class)
+    public void should_throw_exception_given_mutually_exclusive_options() {
+        new GcsClientConfig(Map.of(
+                GcsClientConfig.GCS_BUCKET_NAME_CONFIG, "test-bucket",
+                GcsClientConfig.GCS_CREDENTIALS_JSON_CONFIG, "{}",
+                GcsClientConfig.GCS_CREDENTIALS_PATH_CONFIG, "/tmp/path"
+        ));
+    }
+}

--- a/connect-file-pulse-filesystems/filepulse-google-cloud-storage-fs/src/test/java/io/streamthoughts/kafka/connect/filepulse/storage/gcp/GcsStorageTest.java
+++ b/connect-file-pulse-filesystems/filepulse-google-cloud-storage-fs/src/test/java/io/streamthoughts/kafka/connect/filepulse/storage/gcp/GcsStorageTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.kafka.connect.filepulse.storage.gcp;
+
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+public class GcsStorageTest {
+
+    private static final String testBucketName = "test-bucket";
+
+    private Storage service;
+    private GcsStorage storage;
+    public static final String TEST_BLOB_PATH = "test/path/foo.txt";
+    public static final URI TEST_BLOB_URI = URI.create("gc://" + testBucketName + "/" + TEST_BLOB_PATH);
+
+    @Before
+    public void setUp() {
+        service = LocalStorageHelper.getOptions().getService();
+        BlobInfo blobInfo = BlobInfo
+                .newBuilder(BlobId.of(testBucketName, TEST_BLOB_PATH))
+                .build();
+        service.create(blobInfo, "randomContent".getBytes(StandardCharsets.UTF_8));
+        storage = new GcsStorage(service);
+    }
+
+    @After
+    public void tearDown() {
+
+    }
+
+    @Test
+    public void should_get_input_stream_given_valid_blob_uri() {
+        final InputStream is = storage.getInputStream(TEST_BLOB_URI);
+        Assert.assertNotNull(is);
+    }
+
+    @Test
+    public void should_get_blob_given_valid_uri() throws IOException {
+        Assert.assertNotNull(storage.getBlob(TEST_BLOB_URI));
+    }
+}

--- a/connect-file-pulse-filesystems/filepulse-google-cloud-storage-fs/src/test/java/io/streamthoughts/kafka/connect/filepulse/storage/gcp/reader/GcsRowFileInputReaderTest.java
+++ b/connect-file-pulse-filesystems/filepulse-google-cloud-storage-fs/src/test/java/io/streamthoughts/kafka/connect/filepulse/storage/gcp/reader/GcsRowFileInputReaderTest.java
@@ -1,0 +1,113 @@
+package io.streamthoughts.kafka.connect.filepulse.storage.gcp.reader;
+
+/*
+ * Copyright 2019-2021 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper;
+import io.streamthoughts.kafka.connect.filepulse.data.TypedStruct;
+import io.streamthoughts.kafka.connect.filepulse.reader.FileInputIterator;
+import io.streamthoughts.kafka.connect.filepulse.reader.RecordsIterable;
+import io.streamthoughts.kafka.connect.filepulse.source.FileRecord;
+import io.streamthoughts.kafka.connect.filepulse.source.GenericFileObjectMeta;
+import io.streamthoughts.kafka.connect.filepulse.storage.gcp.GcsStorage;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+public class GcsRowFileInputReaderTest {
+
+    private static final String LF = "\n";
+
+    private static final String TEST_BUCKET_NAME = "test-bucket";
+    private static final String TEST_BLOB_NAME = "test.csv";
+
+    private static final int NLINES = 10;
+
+    @Rule
+    public TemporaryFolder testFolder = new TemporaryFolder();
+
+    private GcsRowFileInputReader reader;
+
+    @Before
+    public void setUp() throws Exception {
+        final File objectFile = testFolder.newFile();
+        try (BufferedWriter writer = Files.newBufferedWriter(objectFile.toPath(), Charset.defaultCharset())) {
+            generateLines(writer);
+        }
+
+        Storage service = LocalStorageHelper.getOptions().getService();
+
+        BlobInfo blobInfo = BlobInfo
+                .newBuilder(BlobId.of(TEST_BUCKET_NAME, TEST_BLOB_NAME))
+                .build();
+
+        service.createFrom(blobInfo, objectFile.toPath());
+
+        reader = new GcsRowFileInputReader();
+        reader.setStorage(new GcsStorage(service));
+        reader.configure(new HashMap<>());
+    }
+
+    @After
+    public void tearDown() {
+        reader.close();
+    }
+
+    @Test
+    public void should_read_all_lines() {
+        final GenericFileObjectMeta meta = new GenericFileObjectMeta.Builder()
+                .withUri(GcsStorage.createBlobURI(TEST_BUCKET_NAME, TEST_BLOB_NAME))
+                .build();
+
+        final FileInputIterator<FileRecord<TypedStruct>> iterator = reader.newIterator(meta.uri());
+        List<FileRecord<TypedStruct>> results = new ArrayList<>();
+        while (iterator.hasNext()) {
+            final RecordsIterable<FileRecord<TypedStruct>> next = iterator.next();
+            results.addAll(next.collect());
+        }
+        Assert.assertEquals(10, results.size());
+    }
+
+    private void generateLines(final BufferedWriter writer) throws IOException {
+
+        for (int i = 0; i < NLINES; i++) {
+            String line = "00000000-" + i;
+            writer.write(line);
+            if (i + 1 < NLINES) {
+                writer.write(LF);
+            }
+        }
+        writer.flush();
+    }
+}

--- a/connect-file-pulse-filesystems/pom.xml
+++ b/connect-file-pulse-filesystems/pom.xml
@@ -36,6 +36,7 @@
         <module>filepulse-local-fs</module>
         <module>filepulse-amazons3-fs</module>
         <module>filepulse-azure-storage-fs</module>
+        <module>filepulse-google-cloud-storage-fs</module>
     </modules>
 
     <properties>

--- a/connect-file-pulse-plugin/pom.xml
+++ b/connect-file-pulse-plugin/pom.xml
@@ -229,6 +229,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.streamthoughts</groupId>
+            <artifactId>kafka-connect-filepulse-google-cloud-storage-fs</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <scope>provided</scope>


### PR DESCRIPTION
This commit adds classes to read object files from a GCS bucket:
- GcsStorage
- GcsFileSystemListing
- GcsAvroFileInputReader
- GcsBytesArrayInputReader
- GcsRowFileInputReader
- GcsFileInputMetadataReader
- GcsXMLFileInputReadr

Resolves: #121