### PR TITLE
last maven version ( > 3.8.1 ) require https repository endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
 
     <properties>
         <apache.avro.version>1.8.2</apache.avro.version>
-        <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
+        <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <io.confluent.version>6.2.1</io.confluent.version>
         <org.apache.kafka.version>2.8.0</org.apache.kafka.version>
         <junit.version>4.13.1</junit.version>


### PR DESCRIPTION
With a recent maven version (3.8.5), the confluent dependency management failed

`
[ERROR] Failed to execute goal on project kafka-connect-filepulse-api: Could not resolve dependencies for project io.streamthoughts:kafka-connect-filepulse-api:jar:2.7.0-SNAPSHOT: Failed to collect dependencies at io.confluent:kafka-schema-registry-client:jar:6.2.1: Failed to read artifact descriptor for io.confluent:kafka-schema-registry-client:jar:6.2.1: Could not transfer artifact io.confluent:kafka-schema-registry-client:pom:6.2.1 from/to maven-default-http-blocker (http://0.0.0.0/): Blocked mirror for repositories: [confluent (http://packages.confluent.io/maven/, default, releases+snapshots)] -> [Help 1]  
`

Recent version expect to use HTTPS in the endpoint repository