### PR TITLE
fix: Add application/gzip to recognize gzipped files

### DIFF
--- a/connect-file-pulse-filesystems/filepulse-local-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/codec/GZipCodec.java
+++ b/connect-file-pulse-filesystems/filepulse-local-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/codec/GZipCodec.java
@@ -42,6 +42,7 @@ public class GZipCodec implements CodecHandler {
 
     static  {
         MIME_TYPES.add("application/x-gzip");
+        MIME_TYPES.add("application/gzip");
     }
 
     /**


### PR DESCRIPTION
Currently pulse only decompress gz files that are created with the "application/x-gzip" MIME type. This adds support for "application/gzip" MIME type. 