### PR TITLE
fix(filters): fix wrong index for DelimitedRowIndex

### DIFF
--- a/connect-file-pulse-api/src/main/java/io/streamthoughts/kafka/connect/filepulse/data/StructSchema.java
+++ b/connect-file-pulse-api/src/main/java/io/streamthoughts/kafka/connect/filepulse/data/StructSchema.java
@@ -110,6 +110,15 @@ public class StructSchema implements Schema, Iterable<TypedField> {
         return ordered;
     }
 
+    public List<TypedField> fieldsByIndex() {
+        ArrayList<TypedField> ordered = new ArrayList<>(fields.values());
+        // order elements in array to match field column index
+        for (TypedField field: fields.values()) {
+            ordered.add(field.index(),field);
+        }
+        return ordered;
+    }
+
     void set(final String fieldName, final Schema fieldSchema) {
         if (fieldName == null || fieldName.isEmpty()) {
             throw new DataException("fieldName cannot be null.");

--- a/connect-file-pulse-filters/src/main/java/io/streamthoughts/kafka/connect/filepulse/filter/AbstractDelimitedRowFilter.java
+++ b/connect-file-pulse-filters/src/main/java/io/streamthoughts/kafka/connect/filepulse/filter/AbstractDelimitedRowFilter.java
@@ -75,7 +75,7 @@ public abstract class AbstractDelimitedRowFilter<T extends AbstractRecordFilter<
 
         this.schema = this.configs.schema();
         if (schema != null) {
-            final List<TypedField> fields = schema.fields();
+            final List<TypedField> fields = schema.fieldsByIndex();
             IntStream.range(0, fields.size()).forEach(i -> columnsTypesByIndex.put(i, fields.get(i)));
         }
     }

--- a/connect-file-pulse-filters/src/test/java/io/streamthoughts/kafka/connect/filepulse/filter/DelimitedRowFilterTest.java
+++ b/connect-file-pulse-filters/src/test/java/io/streamthoughts/kafka/connect/filepulse/filter/DelimitedRowFilterTest.java
@@ -159,6 +159,23 @@ public class DelimitedRowFilterTest {
     }
 
     @Test
+    public void should_use_configured_schema_when_field_names_out_of_order() {
+        configs.put(READER_FIELD_COLUMNS_CONFIG, "x1:STRING;c2:INTEGER;y3:BOOLEAN");
+        filter.configure(configs, alias -> null);
+        RecordsIterable<TypedStruct> output = filter.apply(null, DEFAULT_STRUCT, false);
+        Assert.assertNotNull(output);
+        Assert.assertEquals(1, output.size());
+
+        final TypedStruct record = output.iterator().next();
+        Assert.assertEquals(Type.STRING, record.get("x1").type());
+        Assert.assertEquals(Type.INTEGER, record.get("c2").type());
+        Assert.assertEquals(Type.BOOLEAN, record.get("y3").type());
+        Assert.assertEquals("value1", record.getString("x1"));
+        Assert.assertEquals(2, record.getInt("c2").intValue());
+        Assert.assertTrue(record.getBoolean("y3"));
+    }
+
+    @Test
     public void should_only_convert_non_empty_values_given_schema() {
         // Given
         configs.put(READER_FIELD_COLUMNS_CONFIG, "c1:STRING;c2:INTEGER;c3:BOOLEAN");


### PR DESCRIPTION
DelimitedRowIndex schema has the wrong mapping of field names to index when the field names in the schema are not in alphabetical order. See `DelimitedRowFilterTest::should_use_configured_schema_when_field_names_out_of_order`