### PR TITLE
feat(plugin): add tasks.file.status.storage.topic.creation.enable props

### DIFF
--- a/connect-file-pulse-api/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/KafkaStateBackingStore.java
+++ b/connect-file-pulse-api/src/main/java/io/streamthoughts/kafka/connect/filepulse/storage/KafkaStateBackingStore.java
@@ -62,7 +62,7 @@ public class KafkaStateBackingStore<T> implements StateBackingStore<T> {
      * @param groupId   the group attached to the backing topic (i.e., the connector-name).
      * @param producerProps   the kafka producer properties.
      * @param consumerProps   the kafka consumer properties.
-     * @param serde     the state serdes.
+     * @param serde     the {@link StateSerde}.
      */
     public KafkaStateBackingStore(final String topic,
                                   final String keyPrefix,

--- a/connect-file-pulse-plugin/src/main/java/io/streamthoughts/kafka/connect/filepulse/state/KafkaFileObjectStateBackingStore.java
+++ b/connect-file-pulse-plugin/src/main/java/io/streamthoughts/kafka/connect/filepulse/state/KafkaFileObjectStateBackingStore.java
@@ -62,15 +62,17 @@ public class KafkaFileObjectStateBackingStore implements FileObjectStateBackingS
                 config.getTaskStorageConsumerEnabled()
         );
 
-        try (AdminClient client = AdminClient.create(config.getAdminClientTaskStorageConfigs())) {
-            Map<String, String> topicConfig = new HashMap<>();
-            topicConfig.put(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT);
-            final NewTopic newTopic = new NewTopic(
-                config.getTaskStorageTopic(),
-                config.getTopicPartitions(),
-                config.getReplicationFactor()
-            ).configs(topicConfig);
-            createTopic(client, newTopic);
+        if (config.isTopicCreationEnable()) {
+            try (AdminClient client = AdminClient.create(config.getAdminClientTaskStorageConfigs())) {
+                Map<String, String> topicConfig = new HashMap<>();
+                topicConfig.put(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT);
+                final NewTopic newTopic = new NewTopic(
+                        config.getTaskStorageTopic(),
+                        config.getTopicPartitions(),
+                        config.getReplicationFactor()
+                ).configs(topicConfig);
+                createTopic(client, newTopic);
+            }
         }
     }
 

--- a/connect-file-pulse-plugin/src/main/java/io/streamthoughts/kafka/connect/filepulse/state/KafkaFileObjectStateBackingStoreConfig.java
+++ b/connect-file-pulse-plugin/src/main/java/io/streamthoughts/kafka/connect/filepulse/state/KafkaFileObjectStateBackingStoreConfig.java
@@ -50,6 +50,10 @@ public final class KafkaFileObjectStateBackingStoreConfig extends AbstractConfig
     public static final String TASKS_FILE_STATUS_STORAGE_TOPIC_REPLICATION_FACTOR_CONFIG = TASKS_FILE_STATUS_STORAGE_PREFIX + "topic.replication.factor";
     public static final String TASKS_FILE_STATUS_STORAGE_TOPIC_REPLICATION_FACTOR_DOC = "The replication factor to be used for the status storage topic.";
 
+    public static final String TASKS_FILE_STATUS_STORAGE_TOPIC_CREATION_ENABLE_CONFIG = TASKS_FILE_STATUS_STORAGE_PREFIX + "topic.creation.enable";
+    public static final String TASKS_FILE_STATUS_STORAGE_TOPIC_CREATION_ENABLE_DOC = "Boolean to indicate if the status storage topic should be automatically created.";
+
+
     /**
      * Creates a new {@link KafkaFileObjectStateBackingStoreConfig} instance.
      *
@@ -69,6 +73,9 @@ public final class KafkaFileObjectStateBackingStoreConfig extends AbstractConfig
 
     public String getTaskStorageName() {
         return this.getString(TASKS_FILE_STATUS_STORAGE_NAME_CONFIG);
+    }
+    public boolean isTopicCreationEnable() {
+        return this.getBoolean(TASKS_FILE_STATUS_STORAGE_TOPIC_CREATION_ENABLE_CONFIG);
     }
 
     public Map<String, Object> getConsumerTaskStorageConfigs() {
@@ -100,7 +107,7 @@ public final class KafkaFileObjectStateBackingStoreConfig extends AbstractConfig
         Map<String, Object> originals = originalsWithPrefix(TASKS_FILE_STATUS_STORAGE_PREFIX, true);
         Map<String, Object> adminClientConfigs = new HashMap<>(originals);
         adminClientConfigs.putAll(originalsWithPrefix(TASKS_FILE_STATUS_STORAGE_PREFIX + "admin."));
-        return KafkaUtils.getAdminClientConfigs(originals);
+        return KafkaUtils.getAdminClientConfigs(adminClientConfigs);
     }
 
     private Map<String, Object> getInternalKafkaConsumerConfigs() {
@@ -148,6 +155,17 @@ public final class KafkaFileObjectStateBackingStoreConfig extends AbstractConfig
                         groupCounter++,
                         ConfigDef.Width.NONE,
                         TASKS_FILE_STATUS_STORAGE_BOOTSTRAP_SERVERS_CONFIG
+                )
+                .define(
+                        TASKS_FILE_STATUS_STORAGE_TOPIC_CREATION_ENABLE_CONFIG,
+                        ConfigDef.Type.BOOLEAN,
+                        true,
+                        ConfigDef.Importance.HIGH,
+                        TASKS_FILE_STATUS_STORAGE_TOPIC_CREATION_ENABLE_DOC,
+                        GROUP,
+                        groupCounter++,
+                        ConfigDef.Width.NONE,
+                        TASKS_FILE_STATUS_STORAGE_TOPIC_CREATION_ENABLE_CONFIG
                 )
                 .define(
                         TASKS_FILE_STATUS_STORAGE_TOPIC_REPLICATION_FACTOR_CONFIG,

--- a/connect-file-pulse-plugin/src/test/java/io/streamthoughts/kafka/connect/filepulse/state/KafkaFileObjectStateBackingStoreConfigTest.java
+++ b/connect-file-pulse-plugin/src/test/java/io/streamthoughts/kafka/connect/filepulse/state/KafkaFileObjectStateBackingStoreConfigTest.java
@@ -114,4 +114,35 @@ class KafkaFileObjectStateBackingStoreConfigTest {
         Assertions.assertNotNull(producerConfigs.get(ProducerConfig.ACKS_CONFIG));
     }
 
+    @Test
+    void should_return_topic_creation_disable_configs_given_false_props() {
+        // GIVEN
+        var config = new KafkaFileObjectStateBackingStoreConfig(Map.of(
+                KafkaFileObjectStateBackingStoreConfig.TASKS_FILE_STATUS_STORAGE_NAME_CONFIG, "???",
+                KafkaFileObjectStateBackingStoreConfig.TASKS_FILE_STATUS_STORAGE_BOOTSTRAP_SERVERS_CONFIG, "???",
+                KafkaFileObjectStateBackingStoreConfig.TASKS_FILE_STATUS_STORAGE_TOPIC_CREATION_ENABLE_CONFIG, false
+        ));
+
+        // WHEN
+        boolean enable = config.isTopicCreationEnable();
+
+        // THEN
+        Assertions.assertFalse(enable);
+    }
+
+    @Test
+    void should_return_topic_creation_enable_configs_given_true_props() {
+        // GIVEN
+        var config = new KafkaFileObjectStateBackingStoreConfig(Map.of(
+                KafkaFileObjectStateBackingStoreConfig.TASKS_FILE_STATUS_STORAGE_NAME_CONFIG, "???",
+                KafkaFileObjectStateBackingStoreConfig.TASKS_FILE_STATUS_STORAGE_BOOTSTRAP_SERVERS_CONFIG, "???",
+                KafkaFileObjectStateBackingStoreConfig.TASKS_FILE_STATUS_STORAGE_TOPIC_CREATION_ENABLE_CONFIG, true
+        ));
+
+        // WHEN
+        boolean enable = config.isTopicCreationEnable();
+
+        // THEN
+        Assertions.assertTrue(enable);
+    }
 }


### PR DESCRIPTION
This commit adds a new boolean property to indicate if the status storage topic should be automatically created.