### PR TITLE
perf(plugin): optimize aws s3 file listing

### DIFF
--- a/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/AmazonS3FileSystemListing.java
+++ b/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/AmazonS3FileSystemListing.java
@@ -95,11 +95,6 @@ public class AmazonS3FileSystemListing implements FileSystemListing<AmazonS3Stor
 
                 objectMetaList.addAll(objectListing.getObjectSummaries()
                         .stream()
-                        .map(s3ObjectSummary ->
-                                new S3BucketKey(
-                                        s3ObjectSummary.getBucketName(),
-                                        s3ObjectSummary.getKey()
-                                ))
                         .map(s3Storage::getObjectMetadata)
                         .filter(Objects::nonNull)
                         .collect(Collectors.toList()));


### PR DESCRIPTION
Lower number of requests sent to S3 while listing objects. For buckets with large number of objects, listing can take some time, because there is a request for metadata sent to s3 for each object in the bucket. This is redundant, because all data needed for objects listing are available in S3ObjectSummary. This reduce listing time significantly.

Resolves: #490