### PR TITLE
pin guava version to fix missing class errors

### DIFF
--- a/connect-file-pulse-filesystems/filepulse-google-cloud-storage-fs/pom.xml
+++ b/connect-file-pulse-filesystems/filepulse-google-cloud-storage-fs/pom.xml
@@ -75,5 +75,10 @@ limitations under the License.
             <version>0.127.3</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>32.1.1-jre</version>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
the current image doesn't work and generate errors due to an old version of guava being pulled by default.
The reason for it is that [sbt doesn't support BOM](https://cloud.google.com/java/docs/bom), therefor the guava version needs to be pinned manually. 