### PR TITLE
feat(plugin): Delete the compressed file after extraction

### DIFF
--- a/connect-file-pulse-filesystems/filepulse-local-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/LocalFSDirectoryListingConfig.java
+++ b/connect-file-pulse-filesystems/filepulse-local-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/LocalFSDirectoryListingConfig.java
@@ -12,30 +12,37 @@ import org.apache.kafka.common.config.ConfigDef;
 
 public class LocalFSDirectoryListingConfig extends AbstractConfig {
 
-
     public static final String FS_LISTING_DIRECTORY_PATH = "fs.listing.directory.path";
     public static final String FS_LISTING_DIRECTORY_DOC = "The input directory to scan";
 
-    public static final String FS_RECURSIVE_SCAN_ENABLE_CONFIG  = "fs.listing.recursive.enabled";
-    private static final String FS_RECURSIVE_SCAN_ENABLE_DOC    = "Boolean indicating whether local directory " +
-                                                                  "should be recursively scanned (default true).";
+    public static final String FS_RECURSIVE_SCAN_ENABLE_CONFIG = "fs.listing.recursive.enabled";
+    private static final String FS_RECURSIVE_SCAN_ENABLE_DOC = "Boolean indicating whether local directory " +
+            "should be recursively scanned (default true).";
+
+    public static final String FS_DELETE_COMPRESS_FILES_ENABLED_CONFIG = "fs.delete.compress.files.enabled";
+    private static final String FS_DELETE_COMPRESS_FILES_ENABLE_DOC = "Flag indicating whether compressed file  " +
+            "should be deleted after extraction (default false)";
 
     public static ConfigDef getConf() {
         return new ConfigDef()
-            .define(
-                    FS_LISTING_DIRECTORY_PATH,
-                    ConfigDef.Type.STRING,
-                    ConfigDef.Importance.HIGH,
-                    FS_LISTING_DIRECTORY_DOC
-            )
-                
-            .define(
-                    FS_RECURSIVE_SCAN_ENABLE_CONFIG,
-                    ConfigDef.Type.BOOLEAN,
-                    true,
-                    ConfigDef.Importance.MEDIUM,
-                    FS_RECURSIVE_SCAN_ENABLE_DOC
-            );
+                .define(
+                        FS_LISTING_DIRECTORY_PATH,
+                        ConfigDef.Type.STRING,
+                        ConfigDef.Importance.HIGH,
+                        FS_LISTING_DIRECTORY_DOC)
+
+                .define(
+                        FS_RECURSIVE_SCAN_ENABLE_CONFIG,
+                        ConfigDef.Type.BOOLEAN,
+                        true,
+                        ConfigDef.Importance.MEDIUM,
+                        FS_RECURSIVE_SCAN_ENABLE_DOC)
+                .define(
+                        FS_DELETE_COMPRESS_FILES_ENABLED_CONFIG,
+                        ConfigDef.Type.BOOLEAN,
+                        false,
+                        ConfigDef.Importance.MEDIUM,
+                        FS_DELETE_COMPRESS_FILES_ENABLE_DOC);
     }
 
     /**
@@ -52,5 +59,9 @@ public class LocalFSDirectoryListingConfig extends AbstractConfig {
 
     public String listingDirectoryPath() {
         return this.getString(FS_LISTING_DIRECTORY_PATH);
+    }
+
+    public boolean isDeleteCompressFileEnable() {
+        return getBoolean(FS_DELETE_COMPRESS_FILES_ENABLED_CONFIG);
     }
 }

--- a/connect-file-pulse-plugin/src/test/java/io/streamthoughts/kafka/connect/filepulse/offset/DefaultOffsetPolicyTest.java
+++ b/connect-file-pulse-plugin/src/test/java/io/streamthoughts/kafka/connect/filepulse/offset/DefaultOffsetPolicyTest.java
@@ -13,10 +13,20 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class DefaultOffsetPolicyTest {
+
+    private String getValidPath() {
+        String validPath = SystemUtils.OS_NAME;
+        if (validPath.contains("Windows")) {
+            return "C:\\tmp\\path";
+        } else {
+            return "/tmp/path";
+        }
+    }
 
     private static final GenericFileObjectMeta metadata = new GenericFileObjectMeta(
             URI.create("file:///tmp/path/test"),
@@ -24,8 +34,7 @@ public class DefaultOffsetPolicyTest {
             0L,
             123L,
             new FileObjectMeta.ContentDigest("789", "dummy"),
-            Collections.singletonMap(LocalFileObjectMeta.SYSTEM_FILE_INODE_META_KEY, "456L")
-    );
+            Collections.singletonMap(LocalFileObjectMeta.SYSTEM_FILE_INODE_META_KEY, "456L"));
 
     @Test(expected = IllegalArgumentException.class)
     public void should_throw_illegal_argument_given_empty_strategy() {
@@ -46,7 +55,7 @@ public class DefaultOffsetPolicyTest {
     public void should_get_offset_based_on_path() {
         Map<String, Object> result = new DefaultSourceOffsetPolicy("PATH").toPartitionMap(metadata);
         Assert.assertEquals(1, result.size());
-        Assert.assertEquals("/tmp/path", result.get("path"));
+        Assert.assertEquals(getValidPath(), result.get("path"));
     }
 
     @Test
@@ -76,7 +85,7 @@ public class DefaultOffsetPolicyTest {
     public void should_get_composed_offset_based_on_path_and_hash() {
         Map<String, Object> result = new DefaultSourceOffsetPolicy("PATH+HASH").toPartitionMap(metadata);
         Assert.assertEquals(2, result.size());
-        Assert.assertEquals("/tmp/path", result.get("path"));
+        Assert.assertEquals(getValidPath(), result.get("path"));
         Assert.assertEquals("789", result.get("hash"));
     }
 

--- a/docs/content/en/docs/Developer Guide/file-system-listing/local-filesystem.md
+++ b/docs/content/en/docs/Developer Guide/file-system-listing/local-filesystem.md
@@ -19,10 +19,11 @@ Use the following property in your Connector's configuration:
 
 The following table describes the properties that can be used to configure the `LocalFSDirectoryListing`:
 
-| Configuration                  | Description                                                           | Type      | Default | Importance |
-|--------------------------------|-----------------------------------------------------------------------|-----------|---------|------------|
-| `fs.listing.directory.path`    | The input directory to scan                                           | `string`  | -       | HIGH       |
-| `fs.listing.recursive.enabled` | Flag indicating whether local directory should be recursively scanned | `boolean` | `true`  | MEDIUM     |
+| Configuration                      | Description                                                                | Type      | Default | Importance |
+| ---------------------------------- | -------------------------------------------------------------------------- | --------- | ------- | ---------- |
+| `fs.listing.directory.path`        | The input directory to scan                                                | `string`  | -       | HIGH       |
+| `fs.listing.recursive.enabled`     | Flag indicating whether local directory should be recursively scanned      | `boolean` | `true`  | MEDIUM     |
+| `fs.delete.compress.files.enabled` | Flag indicating whether compressed file should be deleted after extraction | `boolean` | `false` | MEDIUM     |
 
 ## Supported File types
 


### PR DESCRIPTION
feat: (plugin): Add a configuration to delete the compressed file after extraction<subject>

Add the `flag fs.delete.compress.files.enabled` indicating whether compressed file should be deleted after extraction. 
This flag is added to avoid an infinit loop when using a compressed file with the following configuration: 
"offset.attributes.string": "name+lastModified",
"fs.cleanup.policy.class": "io.streamthoughts.kafka.connect.filepulse.fs.clean.LocalMoveCleanupPolicy",
Im fact, if the compressed file is not removed, once extracted, the extracted file is processed, and move to the preconfigured folder. Therefore, the compressed file will be extrated again with a new lastModified value, and the extracted file would be processed again.

When using zipped file, is there any reason , why the zipped file is not removed from the directoty once unzipped? #603
