### PR TITLE
Align the name of the container from “broker” to “kafka”

### DIFF
--- a/docs/content/en/docs/Getting started/_index.md
+++ b/docs/content/en/docs/Getting started/_index.md
@@ -1,5 +1,5 @@
 ---
-date: 2022-06-06
+date: 2024-09-09
 title: "Getting Started"
 linkTitle: "Getting Started"
 weight: 10
@@ -69,7 +69,7 @@ curl -X GET http://localhost:8083/connectors/connect-file-pulse-quickstart-log4j
 $ docker exec -it -e KAFKA_OPTS="" connect kafka-avro-console-consumer \
 --topic connect-file-pulse-quickstart-log4j \
 --from-beginning \
---bootstrap-server broker:29092 \
+--bootstrap-server kafka:29092 \
 --property schema.registry.url=http://schema-registry:8081
 ```
 
@@ -91,7 +91,7 @@ Connect File Pulse use an internal topic to track the current state of files bei
 $ docker exec -it -e KAFKA_OPTS="" connect kafka-console-consumer \
 --topic connect-file-pulse-status \
 --from-beginning \
---bootstrap-server broker:29092
+--bootstrap-server kafka:29092
 ```
 
 (output)
@@ -146,7 +146,7 @@ docker logs --tail="all" -f connect | grep "source task is transitioning to IDLE
 $ docker exec -it connect kafka-avro-console-consumer \
 --topic connect-file-pulse-quickstart-csv \
 --from-beginning \
---bootstrap-server broker:29092 \
+--bootstrap-server kafka:29092 \
 --property schema.registry.url=http://schema-registry:8081
 ```
 

--- a/examples/connect-file-pulse-example-override-topic-and-key.json
+++ b/examples/connect-file-pulse-example-override-topic-and-key.json
@@ -19,7 +19,7 @@
   "topic": "connect-file-pulse-quickstart-csv",
   "tasks.reader.class": "io.streamthoughts.kafka.connect.filepulse.fs.reader.LocalRowFileInputReader",
   "tasks.file.status.storage.class": "io.streamthoughts.kafka.connect.filepulse.state.KafkaFileObjectStateBackingStore",
-  "tasks.file.status.storage.bootstrap.servers": "broker:29092",
+  "tasks.file.status.storage.bootstrap.servers": "kafka:29092",
   "tasks.file.status.storage.topic": "connect-file-pulse-status",
   "tasks.file.status.storage.topic.partitions": 10,
   "tasks.file.status.storage.topic.replication.factor": 1,

--- a/examples/connect-file-pulse-quickstart-avro.json
+++ b/examples/connect-file-pulse-quickstart-avro.json
@@ -10,7 +10,7 @@
   "topic": "connect-file-pulse-quickstart-avro",
   "tasks.reader.class": "io.streamthoughts.kafka.connect.filepulse.fs.reader.LocalAvroFileInputReader",
   "tasks.file.status.storage.class": "io.streamthoughts.kafka.connect.filepulse.state.KafkaFileObjectStateBackingStore",
-  "tasks.file.status.storage.bootstrap.servers": "broker:29092",
+  "tasks.file.status.storage.bootstrap.servers": "kafka:29092",
   "tasks.file.status.storage.topic": "connect-file-pulse-status",
   "tasks.file.status.storage.topic.partitions": 10,
   "tasks.file.status.storage.topic.replication.factor": 1,

--- a/examples/connect-file-pulse-quickstart-csv.json
+++ b/examples/connect-file-pulse-quickstart-csv.json
@@ -21,7 +21,7 @@
   "topic": "connect-file-pulse-quickstart-csv",
   "tasks.reader.class": "io.streamthoughts.kafka.connect.filepulse.fs.reader.LocalRowFileInputReader",
   "tasks.file.status.storage.class": "io.streamthoughts.kafka.connect.filepulse.state.KafkaFileObjectStateBackingStore",
-  "tasks.file.status.storage.bootstrap.servers": "broker:29092",
+  "tasks.file.status.storage.bootstrap.servers": "kafka:29092",
   "tasks.file.status.storage.topic": "connect-file-pulse-status",
   "tasks.file.status.storage.topic.partitions": 10,
   "tasks.file.status.storage.topic.replication.factor": 1,

--- a/examples/connect-file-pulse-quickstart-log4j.json
+++ b/examples/connect-file-pulse-quickstart-log4j.json
@@ -22,7 +22,7 @@
   "topic": "connect-file-pulse-quickstart-log4j",
   "tasks.reader.class": "io.streamthoughts.kafka.connect.filepulse.fs.reader.LocalRowFileInputReader",
   "tasks.file.status.storage.class": "io.streamthoughts.kafka.connect.filepulse.state.KafkaFileObjectStateBackingStore",
-  "tasks.file.status.storage.bootstrap.servers": "broker:29092",
+  "tasks.file.status.storage.bootstrap.servers": "kafka:29092",
   "tasks.file.status.storage.topic": "connect-file-pulse-status",
   "tasks.file.status.storage.topic.partitions": 10,
   "tasks.file.status.storage.topic.replication.factor": 1,

--- a/examples/connect-file-pulse-quickstart-raw.json
+++ b/examples/connect-file-pulse-quickstart-raw.json
@@ -10,7 +10,7 @@
   "topic": "connect-file-pulse-quickstart-csv",
   "tasks.reader.class": "io.streamthoughts.kafka.connect.filepulse.fs.reader.LocalBytesArrayInputReader",
   "tasks.file.status.storage.class": "io.streamthoughts.kafka.connect.filepulse.state.KafkaFileObjectStateBackingStore",
-  "tasks.file.status.storage.bootstrap.servers": "broker:29092",
+  "tasks.file.status.storage.bootstrap.servers": "kafka:29092",
   "tasks.file.status.storage.topic": "connect-file-pulse-status",
   "tasks.file.status.storage.topic.partitions": 10,
   "tasks.file.status.storage.topic.replication.factor": 1,

--- a/examples/connect-file-pulse-quickstart-xml.json
+++ b/examples/connect-file-pulse-quickstart-xml.json
@@ -12,7 +12,7 @@
   "reader.xml.parser.namespace.aware.enabled": true,
   "reader.xml.exclude.empty.elements": true,
   "tasks.file.status.storage.class": "io.streamthoughts.kafka.connect.filepulse.state.KafkaFileObjectStateBackingStore",
-  "tasks.file.status.storage.bootstrap.servers": "broker:29092",
+  "tasks.file.status.storage.bootstrap.servers": "kafka:29092",
   "tasks.file.status.storage.topic": "connct-file-pulse-status",
   "tasks.file.status.storage.topic.partitions": 10,
   "tasks.file.status.storage.topic.replication.factor": 1,


### PR DESCRIPTION
The Kafka container used to be named "broker" and is now named "kafka".