### PR TITLE
Add validation for attributes that may be null in S3 Metadata.

### DIFF
--- a/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/AmazonS3Storage.java
+++ b/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/AmazonS3Storage.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Objects;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -257,8 +258,11 @@ public class AmazonS3Storage implements Storage {
         objectMetadata.getUserMetadata().forEach((k, v) -> userDefinedMetadata.put("s3.object.user.metadata." + k, v));
         userDefinedMetadata.put("s3.object.summary.bucketName", s3Object.bucketName());
         userDefinedMetadata.put("s3.object.summary.key", s3Object.key());
-        userDefinedMetadata.put("s3.object.summary.etag", objectMetadata.getETag());
-        userDefinedMetadata.put("s3.object.summary.storageClass", objectMetadata.getStorageClass());
+
+        Optional.ofNullable(objectMetadata.getETag())
+                .ifPresent(it -> userDefinedMetadata.put("s3.object.summary.etag", it));
+        Optional.ofNullable(objectMetadata.getStorageClass())
+                .ifPresent(it -> userDefinedMetadata.put("s3.object.summary.storageClass", it));
 
         final String contentMD5 = objectMetadata.getETag();
 


### PR DESCRIPTION
The `ObjectMetadata#getStorageClass` method and the `ObjectMetadata#getETag` method may both return null. In such cases, these attributes need to be ignored to prevent a NPE issue in ConnectSchemaMapper.