### PR TITLE
fix(plugin): correct regex router cleanup policy typo

### DIFF
--- a/connect-file-pulse-plugin/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/clean/RegexRouterCleanupPolicy.java
+++ b/connect-file-pulse-plugin/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/clean/RegexRouterCleanupPolicy.java
@@ -28,13 +28,13 @@ public final class RegexRouterCleanupPolicy implements FileCleanupPolicy {
 
     public static final String SUCCESS_ROUTE_TOPIC_REGEX_CONFIG = CONFIG_PREFIX + "success.uri.regex";
     private static final String SUCCESS_ROUTE_TOPIC_REGEX_DOC =
-            "Regular expression to use for matching objects in success.";
+        "Regular expression to use for matching objects in success.";
     public static final String SUCCESS_ROUTE_TOPIC_REPLACEMENT_CONFIG = CONFIG_PREFIX + "success.uri.replacement";
     private static final String SUCCESS_ROUTE_TOPIC_REPLACEMENT_DOC = "Replacement string.";
 
     public static final String FAILURE_ROUTE_TOPIC_REGEX_CONFIG = CONFIG_PREFIX + "failure.uri.regex";
     private static final String FAILURE_ROUTE_TOPIC_REGEX_DOC =
-            "Regular expression to use for matching objects in failure.";
+        "Regular expression to use for matching objects in failure.";
     public static final String FAILURE_ROUTE_TOPIC_REPLACEMENT_CONFIG = CONFIG_PREFIX + "failure.uri.replacement";
     private static final String FAILURE_ROUTE_TOPIC_REPLACEMENT_DOC = "Replacement string.";
 
@@ -57,8 +57,8 @@ public final class RegexRouterCleanupPolicy implements FileCleanupPolicy {
         successReplacement = simpleConfig.getString(SUCCESS_ROUTE_TOPIC_REPLACEMENT_CONFIG);
         successRegex = Pattern.compile(simpleConfig.getString(SUCCESS_ROUTE_TOPIC_REGEX_CONFIG));
 
-        failureReplacement = simpleConfig.getString(SUCCESS_ROUTE_TOPIC_REPLACEMENT_CONFIG);
-        failureRegex = Pattern.compile(simpleConfig.getString(SUCCESS_ROUTE_TOPIC_REGEX_CONFIG));
+        failureReplacement = simpleConfig.getString(FAILURE_ROUTE_TOPIC_REPLACEMENT_CONFIG);
+        failureRegex = Pattern.compile(simpleConfig.getString(FAILURE_ROUTE_TOPIC_REGEX_CONFIG));
     }
 
     /**

--- a/connect-file-pulse-plugin/src/test/java/io/streamthoughts/kafka/connect/filepulse/fs/clean/RegexRouterCleanupPolicyTest.java
+++ b/connect-file-pulse-plugin/src/test/java/io/streamthoughts/kafka/connect/filepulse/fs/clean/RegexRouterCleanupPolicyTest.java
@@ -76,8 +76,8 @@ class RegexRouterCleanupPolicyTest {
         try (RegexRouterCleanupPolicy policy = new RegexRouterCleanupPolicy()) {
             policy.setStorage(new LocalFileStorage());
             policy.configure(Map.of(
-                    RegexRouterCleanupPolicy.SUCCESS_ROUTE_TOPIC_REGEX_CONFIG,"(.*).txt",
-                    RegexRouterCleanupPolicy.SUCCESS_ROUTE_TOPIC_REPLACEMENT_CONFIG, "$1-DONE-FAILURE.txt"
+                    RegexRouterCleanupPolicy.FAILURE_ROUTE_TOPIC_REGEX_CONFIG,"(.*).txt",
+                    RegexRouterCleanupPolicy.FAILURE_ROUTE_TOPIC_REPLACEMENT_CONFIG, "$1-DONE-FAILURE.txt"
             ));
 
             URI targetURI = policy.routeOnFailure(source.metadata().uri());


### PR DESCRIPTION
Fix typo in `RegexRouterCleanupPolicy` including tests 