### PR TITLE
feat(filters): support GrokFilter target and string array input

### DIFF
--- a/connect-file-pulse-filters/src/main/java/io/streamthoughts/kafka/connect/filepulse/config/GrokFilterConfig.java
+++ b/connect-file-pulse-filters/src/main/java/io/streamthoughts/kafka/connect/filepulse/config/GrokFilterConfig.java
@@ -14,6 +14,9 @@ public class GrokFilterConfig extends CommonFilterConfig {
 
     private final GrokConfig grok;
     public static final String GROK_FILTER = "GROK_FILTER";
+    
+    public static final String GROK_TARGET_CONFIG = "target";
+    public static final String GROK_TARGET_DOC = "The target field to put the extracted Grok data (optional)";
 
     /**
      * Creates a new {@link GrokFilterConfig} instance.
@@ -29,11 +32,26 @@ public class GrokFilterConfig extends CommonFilterConfig {
         return grok;
     }
 
+    public String target() {
+        return getString(GROK_TARGET_CONFIG);
+    }
+
     public static ConfigDef configDef() {
         int filterGroupCounter = 0;
         final ConfigDef def = new ConfigDef(CommonFilterConfig.configDef())
                 .define(getSourceConfigKey(GROK_FILTER, filterGroupCounter++))
-                .define(getOverwriteConfigKey(GROK_FILTER, filterGroupCounter++));
+                .define(getOverwriteConfigKey(GROK_FILTER, filterGroupCounter++))
+                .define(
+                        GROK_TARGET_CONFIG,
+                        ConfigDef.Type.STRING,
+                    null,
+                        ConfigDef.Importance.HIGH,
+                        GROK_TARGET_DOC,
+                        GROK_FILTER,
+                        filterGroupCounter++,
+                        ConfigDef.Width.NONE,
+                        GROK_TARGET_CONFIG
+                );
         for (ConfigDef.ConfigKey configKey : GrokConfig.configDef().configKeys().values()) {
             def.define(new ConfigDef.ConfigKey(
                     configKey.name,

--- a/connect-file-pulse-filters/src/test/java/io/streamthoughts/kafka/connect/filepulse/filter/GrokFilterTest.java
+++ b/connect-file-pulse-filters/src/test/java/io/streamthoughts/kafka/connect/filepulse/filter/GrokFilterTest.java
@@ -9,6 +9,7 @@ package io.streamthoughts.kafka.connect.filepulse.filter;
 import io.streamthoughts.kafka.connect.filepulse.config.CommonFilterConfig;
 import io.streamthoughts.kafka.connect.filepulse.data.TypedStruct;
 import io.streamthoughts.kafka.connect.transform.GrokConfig;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -86,4 +87,116 @@ public class GrokFilterTest {
         Assert.assertEquals("INFO", struct.getString("LOGLEVEL"));
         Assert.assertEquals("a dummy log message", struct.getString("GREEDYDATA"));
     }
+
+    @Test
+    public void testGivenTargetField() {
+        configs.put(GrokConfig.GROK_PATTERN_CONFIG, GROK_NAMED_CAPTURED_PATTERN);
+        configs.put("target", "logData");
+        filter.configure(configs, alias -> null);
+        List<TypedStruct> results = filter.apply(null, DATA, false).collect();
+
+        Assert.assertEquals(1, results.size());
+        TypedStruct struct = results.get(0);
+        
+        // Original message field should still exist
+        Assert.assertEquals(INPUT, struct.getString("message"));
+        
+        // Extracted data should be in the target field
+        Assert.assertTrue(struct.exists("logData"));
+        TypedStruct logData = struct.getStruct("logData");
+        Assert.assertNotNull(logData);
+        Assert.assertEquals("1970-01-01 00:00:00,000", logData.getString("timestamp"));
+        Assert.assertEquals("INFO", logData.getString("level"));
+        // Inside the target struct, message is just the extracted value (no merging with original)
+        Assert.assertEquals("a dummy log message", logData.getString("message"));
+    }
+
+    @Test
+    public void testGivenTargetFieldWithOverwrite() {
+        configs.put(GrokConfig.GROK_PATTERN_CONFIG, GROK_NAMED_CAPTURED_PATTERN);
+        configs.put("target", "parsed");
+        configs.put(CommonFilterConfig.FILTER_OVERWRITE_CONFIG, "message");
+        filter.configure(configs, alias -> null);
+        List<TypedStruct> results = filter.apply(null, DATA, false).collect();
+
+        Assert.assertEquals(1, results.size());
+        TypedStruct struct = results.get(0);
+        
+        // Original message field should still exist
+        Assert.assertEquals(INPUT, struct.getString("message"));
+        
+        // Extracted data should be in the target field with overwrite applied
+        Assert.assertTrue(struct.exists("parsed"));
+        TypedStruct parsed = struct.getStruct("parsed");
+        Assert.assertNotNull(parsed);
+        Assert.assertEquals("1970-01-01 00:00:00,000", parsed.getString("timestamp"));
+        Assert.assertEquals("INFO", parsed.getString("level"));
+        // With overwrite, message should be a string, not an array
+        Assert.assertEquals("a dummy log message", parsed.getString("message"));
+    }
+
+    @Test
+    public void testGivenArraySourceWithNestedTarget() {
+        TypedStruct record = TypedStruct.create();
+        record.put(
+            "logData",
+            Arrays.asList(
+                "1970-01-01 00:00:00,000 INFO first log message",
+                "1970-01-01 00:00:01,000 WARN second log message",
+                "1970-01-01 00:00:02,000 ERROR third log message"));
+
+        configs.put(GrokConfig.GROK_PATTERN_CONFIG, GROK_NAMED_CAPTURED_PATTERN);
+        configs.put(CommonFilterConfig.FILTER_SOURCE_FIELD_CONFIG, "logData");
+        configs.put("target", "parsed.records");
+        filter.configure(configs, alias -> null);
+
+        List<TypedStruct> results = filter.apply(null, record, false).collect();
+        Assert.assertEquals(1, results.size());
+        TypedStruct struct = results.get(0);
+
+        Assert.assertTrue(struct.exists("parsed"));
+        TypedStruct parsed = struct.getStruct("parsed");
+        Assert.assertNotNull(parsed);
+        Assert.assertTrue(parsed.exists("records"));
+        List<Object> records = parsed.getArray("records");
+        Assert.assertEquals(3, records.size());
+
+        TypedStruct first = (TypedStruct) records.get(0);
+        Assert.assertEquals("1970-01-01 00:00:00,000", first.getString("timestamp"));
+        Assert.assertEquals("INFO", first.getString("level"));
+        Assert.assertEquals("first log message", first.getString("message"));
+
+        TypedStruct last = (TypedStruct) records.get(2);
+        Assert.assertEquals("1970-01-01 00:00:02,000", last.getString("timestamp"));
+        Assert.assertEquals("ERROR", last.getString("level"));
+        Assert.assertEquals("third log message", last.getString("message"));
+    }
+
+    @Test(expected = FilterException.class)
+    public void testGivenArraySourceWithInvalidElementTypeShouldFail() {
+        TypedStruct record = TypedStruct.create().put(
+            "logs",
+            Arrays.asList("1970-01-01 00:00:00,000 INFO first log message", 1));
+
+        configs.put(GrokConfig.GROK_PATTERN_CONFIG, GROK_NAMED_CAPTURED_PATTERN);
+        configs.put(CommonFilterConfig.FILTER_SOURCE_FIELD_CONFIG, "logs");
+        filter.configure(configs, alias -> null);
+
+        filter.apply(null, record, false);
+    }
+
+        @Test(expected = FilterException.class)
+        public void testGivenArraySourceWithNonMatchingEntryShouldFail() {
+        TypedStruct record = TypedStruct.create().put(
+            "logs",
+            Arrays.asList(
+                "1970-01-01 00:00:00,000 INFO first log message",
+                "INVALID"));
+
+        configs.put(GrokConfig.GROK_PATTERN_CONFIG, GROK_NAMED_CAPTURED_PATTERN);
+        configs.put(CommonFilterConfig.FILTER_SOURCE_FIELD_CONFIG, "logs");
+        filter.configure(configs, alias -> null);
+
+        filter.apply(null, record, false);
+        }
 }

--- a/docs/content/en/docs/Developer Guide/filters.md
+++ b/docs/content/en/docs/Developer Guide/filters.md
@@ -632,14 +632,15 @@ The `GrokFilter`is based on: https://github.com/streamthoughts/kafka-connect-tra
 
 ### Configuration
 
-| Configuration        | Description                                   | Type    | Default   | Importance |
-|----------------------|-----------------------------------------------|---------|-----------|------------|
-| `namedCapturesOnly`  | If true, only store named captures from grok. | boolean | *true*    | high       |
-| `pattern`            | The Grok pattern to match.                    | string  | *-*       | high       |
-| `overwrite`          | The fields to overwrite.                      | list    | medium    |
-| `patternDefinitions` | Custom pattern definitions.                   | list    | *-*       | low        |
-| `patternsDir`        | List of user-defined pattern directories      | string  | *-*       | low        |
-| `source`             | The input field on which to apply the filter  | string  | *message* | medium     |
+| Configuration        | Description                                              | Type                   | Default   | Importance |
+|----------------------|----------------------------------------------------------|----------------------- |-----------|------------|
+| `namedCapturesOnly`  | If true, only store named captures from grok.            | boolean                | *true*    | high       |
+| `pattern`            | The Grok pattern to match.                               | string                 | *-*       | high       |
+| `overwrite`          | The fields to overwrite.                                 | list                   |           | medium     |
+| `patternDefinitions` | Custom pattern definitions.                              | list                   | *-*       | low        |
+| `patternsDir`        | List of user-defined pattern directories.                | string                 | *-*       | low        |
+| `source`             | The input field on which to apply the filter             | string / array<string> | *message* | medium     |
+| `target`             | (Optional) Destination field receiving extracted values. | string                 | *-*       | medium     |
 
 ### Examples
 


### PR DESCRIPTION
The GrokFilter is really useful to parse unstructured data. When I tried to use it with a *BytesArrayInputReader I missed 2 things:
- A way to put the extracted fields in a given field and not always have to put these field at the top level.
To solve this, I added support of the `target` field: 

From:
```json
{
  "message": "1970-01-01 00:00:00,000 INFO a dummy log message",
  "timestamp": "1970-01-01 00:00:00,000",
  "level": "INFO"
}
```

To:
```json
"filters.grok.target": "parsed"
```
```json
{
  "message": "1970-01-01 00:00:00,000 INFO a dummy log message",
  "parsed": {
    "message": "a dummy log message",
    "timestamp": "1970-01-01 00:00:00,000",
    "level": "INFO"
  }
}
```

- I need to read a file as a whole to generate 1 single event. When working with *BytesArrayInputRead, SplitFilter to parse the file content (on \n for instance), we can have a string array on which we want to apply the GrokFilter. 
To solve this, I added support of array string input as well as the existing string input.

Note: The following example is not really relevant as we would generally read a log file line by line (it shows the objective)

From:
```json
{
  "message": ["1970-01-01 00:00:00,000 INFO a dummy log message", "1970-01-01 01:00:00,000 INFO a second dummy log message", "1970-01-01 02:00:00,000 INFO a third dummy log message"]
}
```
To:
```json
{
  "parsed": [{
    "message": "a dummy log message",
    "timestamp": "1970-01-01 00:00:00,000",
    "level": "INFO"
  }, {
    "message": "a second dummy log message",
    "timestamp": "1970-01-01 01:00:00,000",
    "level": "INFO"
  }, {
    "message": "a third dummy log message",
    "timestamp": "1970-01-01 00:00:00,000",
    "level": "INFO"
  }]
}
```

This PR enhances the GrokFilter while keeping the original behaviour. Look forward to having your feedback !