### PR TITLE
feat(plugins): support long-lived files streaming

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -42,6 +42,7 @@
     <suppress checks="NPathComplexity" files="DefaultFileRecordsPollingConsumer.java"/>
     <suppress checks="NPathComplexity" files="DefaultFileSystemMonitor.java"/>
     <suppress checks="ParameterNumber" files="InternalFilterContext" />
+    <suppress checks="ParameterNumber" files="DefaultFileSystemMonitor" />
     <suppress checks="Header" files="kafka-connect-source-file-pulse-version.properties"/>
     <suppress checks="Header" files=".*.properties"/>
     <suppress checks="[a-zA-Z0-9]*" files="src/main/java/io/streamthoughts/kafka/connect/filepulse/expression/parser/antlr4/*"/>

--- a/connect-file-pulse-api/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/FileCompletionStrategy.java
+++ b/connect-file-pulse-api/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/FileCompletionStrategy.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) StreamThoughts
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.kafka.connect.filepulse.source;
+
+import java.util.Map;
+
+/**
+ * Strategy interface for determining when a file should be marked as COMPLETED.
+ */
+public interface FileCompletionStrategy {
+
+    /**
+     * Configure this strategy.
+     *
+     * @param configs the configuration properties.
+     */
+    default void configure(final Map<String, ?> configs) {
+        // Default: no-op
+    }
+
+    /**
+     * Check if the file should be marked as completed based on the strategy.
+     *
+     * @param context the file object context.
+     * @return true if the file should be marked as COMPLETED, false otherwise.
+     */
+    boolean shouldComplete(final FileObjectContext context);
+}

--- a/connect-file-pulse-api/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/FileObjectStatus.java
+++ b/connect-file-pulse-api/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/FileObjectStatus.java
@@ -33,6 +33,11 @@ public enum FileObjectStatus {
     READING,
 
     /**
+     * The file processing is partially completed (e.g. for long-lived processing).
+     */
+    PARTIALLY_COMPLETED,
+
+    /**
      * The file processing is completed.
      */
     COMPLETED,

--- a/connect-file-pulse-api/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/LongLivedFileReadStrategy.java
+++ b/connect-file-pulse-api/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/LongLivedFileReadStrategy.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) StreamThoughts
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.kafka.connect.filepulse.source;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Optional strategy interface that can be implemented alongside {@link FileCompletionStrategy}
+ * to influence when the connector should attempt to read from continuously appended files.
+ *
+ * <p>This is intended for long-lived, append-only files (for example, daily log files) where
+ * it may be desirable to back off read attempts when no new data is expected for some time,
+ * in order to avoid unnecessary polling or timeouts while still allowing the completion
+ * strategy to control when the file is eventually marked as COMPLETED.
+ */
+public interface LongLivedFileReadStrategy {
+
+    Logger LOG = LoggerFactory.getLogger(LongLivedFileReadStrategy.class);
+
+    /**
+     * Determines whether the connector should attempt to read from the given file
+     * based on its current context.
+     *
+     * <p>The default implementation checks if the file has been modified since
+     * the last read offset timestamp.
+     *
+     * @param objectMeta the file object metadata.
+     * @param offset     the last read offset for the file.
+     * @return true if the connector should attempt to read from the file, false otherwise.
+     */
+    default boolean shouldAttemptRead(final FileObjectMeta objectMeta, final FileObjectOffset offset) {
+        return objectMeta.lastModified() > offset.timestamp();
+    }
+}

--- a/connect-file-pulse-api/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/StateListener.java
+++ b/connect-file-pulse-api/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/StateListener.java
@@ -41,6 +41,14 @@ public interface StateListener {
     void onCompleted(final FileObjectContext context);
 
     /**
+     * This method is invoked when a source file processing is partially completed.
+     * @see FileRecordsPollingConsumer
+     *
+     * @param context   the file context.
+     */
+    void onPartiallyCompleted(final FileObjectContext context);
+
+    /**
      * This method is invoked when an error occurred while processing a source file.
      * @see FileRecordsPollingConsumer
      *

--- a/connect-file-pulse-filesystems/filepulse-commons-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/reader/text/NonBlockingBufferReader.java
+++ b/connect-file-pulse-filesystems/filepulse-commons-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/reader/text/NonBlockingBufferReader.java
@@ -15,6 +15,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -178,7 +179,7 @@ public class NonBlockingBufferReader implements AutoCloseable {
         TextBlock line;
         do {
             line = tryToExtractLine();
-            if (line != null) {
+            if (line != null && !StringUtils.isEmpty(line.data())) {
                 records.add(line);
             }
             maxNumRecordsNotReached = records.size() < minRecords;

--- a/connect-file-pulse-plugin/src/main/java/io/streamthoughts/kafka/connect/filepulse/config/DailyCompletionStrategyConfig.java
+++ b/connect-file-pulse-plugin/src/main/java/io/streamthoughts/kafka/connect/filepulse/config/DailyCompletionStrategyConfig.java
@@ -1,0 +1,207 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) StreamThoughts
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.kafka.connect.filepulse.config;
+
+import io.streamthoughts.kafka.connect.filepulse.source.DailyCompletionStrategy;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+
+/**
+ * Configuration for {@link DailyCompletionStrategy}.
+ */
+public class DailyCompletionStrategyConfig extends AbstractConfig {
+
+    public static final String COMPLETION_SCHEDULE_TIME_CONFIG = "daily.completion.schedule.time";
+    private static final String COMPLETION_SCHEDULE_TIME_DOC =
+        "Time to complete files in HH:mm:ss format (e.g., '00:01:00'). " +
+        "Files will be marked as COMPLETED when the current time passes this scheduled time " +
+        "for the date extracted from the filename. Uses the system default timezone.";
+    private static final String COMPLETION_SCHEDULE_TIME_DEFAULT = "00:01:00";
+
+    public static final String COMPLETION_SCHEDULE_DATE_PATTERN_CONFIG = "daily.completion.schedule.date.pattern";
+    private static final String COMPLETION_SCHEDULE_DATE_PATTERN_DOC =
+        "Regex pattern to extract date from filename. The pattern should contain capturing groups " +
+        "that match the date components. For example: '.*?(\\d{4}-\\d{2}-\\d{2}).*' to match dates " +
+        "like '2025-12-08' in filenames like 'logs-2025-12-08.log'.";
+    private static final String COMPLETION_SCHEDULE_DATE_PATTERN_DEFAULT = ".*?(\\d{4}-\\d{2}-\\d{2}).*";
+
+    public static final String COMPLETION_SCHEDULE_DATE_FORMAT_CONFIG = "daily.completion.schedule.date.format";
+    private static final String COMPLETION_SCHEDULE_DATE_FORMAT_DOC =
+        "Date format pattern used to parse the date extracted from the filename. " +
+        "Must match the date format in the filename (e.g., 'yyyy-MM-dd' for '2025-12-08', " +
+        "'yyyyMMdd' for '20251208'). See Java DateTimeFormatter for supported patterns.";
+    private static final String COMPLETION_SCHEDULE_DATE_FORMAT_DEFAULT = "yyyy-MM-dd";
+
+    /**
+     * Creates a new {@link DailyCompletionStrategyConfig} instance.
+     *
+     * @param originals the configuration properties
+     */
+    public DailyCompletionStrategyConfig(final Map<?, ?> originals) {
+        super(configDef(), originals);
+    }
+
+    /**
+     * Get the scheduled completion time.
+     *
+     * @return the time at which files should be completed
+     */
+    public LocalTime scheduledCompletionTime() {
+        String timeStr = getString(COMPLETION_SCHEDULE_TIME_CONFIG);
+        try {
+            return LocalTime.parse(timeStr, DateTimeFormatter.ofPattern("HH:mm:ss"));
+        } catch (DateTimeParseException e) {
+            throw new ConfigException(
+                COMPLETION_SCHEDULE_TIME_CONFIG,
+                timeStr,
+                "Invalid time format. Expected format: HH:mm:ss (e.g., '23:59:59')"
+            );
+        }
+    }
+
+    /**
+     * Get the compiled regex pattern for extracting dates from filenames.
+     *
+     * @return the compiled pattern
+     */
+    public Pattern datePattern() {
+        String patternStr = getString(COMPLETION_SCHEDULE_DATE_PATTERN_CONFIG);
+        try {
+            return Pattern.compile(patternStr);
+        } catch (PatternSyntaxException e) {
+            throw new ConfigException(
+                COMPLETION_SCHEDULE_DATE_PATTERN_CONFIG,
+                patternStr,
+                "Invalid regex pattern: " + e.getMessage()
+            );
+        }
+    }
+
+    /**
+     * Get the date formatter for parsing dates from filenames.
+     *
+     * @return the date formatter
+     */
+    public DateTimeFormatter dateFormatter() {
+        String formatStr = getString(COMPLETION_SCHEDULE_DATE_FORMAT_CONFIG);
+        try {
+            return DateTimeFormatter.ofPattern(formatStr);
+        } catch (IllegalArgumentException e) {
+            throw new ConfigException(
+                COMPLETION_SCHEDULE_DATE_FORMAT_CONFIG,
+                formatStr,
+                "Invalid date format pattern: " + e.getMessage()
+            );
+        }
+    }
+
+    /**
+     * Define the configuration.
+     *
+     * @return the configuration definition
+     */
+    public static ConfigDef configDef() {
+        return new ConfigDef()
+            .define(
+                COMPLETION_SCHEDULE_TIME_CONFIG,
+                ConfigDef.Type.STRING,
+                COMPLETION_SCHEDULE_TIME_DEFAULT,
+                new TimeValidator(),
+                ConfigDef.Importance.HIGH,
+                COMPLETION_SCHEDULE_TIME_DOC
+            )
+            .define(
+                COMPLETION_SCHEDULE_DATE_PATTERN_CONFIG,
+                ConfigDef.Type.STRING,
+                COMPLETION_SCHEDULE_DATE_PATTERN_DEFAULT,
+                new RegexValidator(),
+                ConfigDef.Importance.HIGH,
+                COMPLETION_SCHEDULE_DATE_PATTERN_DOC
+            )
+            .define(
+                COMPLETION_SCHEDULE_DATE_FORMAT_CONFIG,
+                ConfigDef.Type.STRING,
+                COMPLETION_SCHEDULE_DATE_FORMAT_DEFAULT,
+                new DateFormatValidator(),
+                ConfigDef.Importance.HIGH,
+                COMPLETION_SCHEDULE_DATE_FORMAT_DOC
+            );
+    }
+
+    /**
+     * Validator for time format (HH:mm:ss).
+     */
+    private static class TimeValidator implements ConfigDef.Validator {
+        @Override
+        public void ensureValid(String name, Object value) {
+            if (value == null) {
+                throw new ConfigException(name, value, "Time configuration is required");
+            }
+            String timeStr = value.toString();
+            try {
+                LocalTime.parse(timeStr, DateTimeFormatter.ofPattern("HH:mm:ss"));
+            } catch (DateTimeParseException e) {
+                throw new ConfigException(
+                    name,
+                    value,
+                    "Invalid time format. Expected format: HH:mm:ss (e.g., '23:59:59')"
+                );
+            }
+        }
+    }
+
+    /**
+     * Validator for regex pattern.
+     */
+    private static class RegexValidator implements ConfigDef.Validator {
+        @Override
+        public void ensureValid(String name, Object value) {
+            if (value == null) {
+                return; // Has default value
+            }
+            String patternStr = value.toString();
+            try {
+                Pattern.compile(patternStr);
+            } catch (PatternSyntaxException e) {
+                throw new ConfigException(
+                    name,
+                    value,
+                    "Invalid regex pattern: " + e.getMessage()
+                );
+            }
+        }
+    }
+
+    /**
+     * Validator for date format pattern.
+     */
+    private static class DateFormatValidator implements ConfigDef.Validator {
+        @Override
+        public void ensureValid(String name, Object value) {
+            if (value == null) {
+                return; // Has default value
+            }
+            String formatStr = value.toString();
+            try {
+                DateTimeFormatter.ofPattern(formatStr);
+            } catch (IllegalArgumentException e) {
+                throw new ConfigException(
+                    name,
+                    value,
+                    "Invalid date format pattern. Use a valid DateTimeFormatter pattern (e.g., 'yyyy-MM-dd')"
+                );
+            }
+        }
+    }
+}

--- a/connect-file-pulse-plugin/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/DailyCompletionStrategy.java
+++ b/connect-file-pulse-plugin/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/DailyCompletionStrategy.java
@@ -1,0 +1,186 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) StreamThoughts
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.kafka.connect.filepulse.source;
+
+import io.streamthoughts.kafka.connect.filepulse.config.DailyCompletionStrategyConfig;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A {@link FileCompletionStrategy} that marks files as COMPLETED
+ * at a scheduled time by extracting the date from the filename.
+ *
+ * <p>This is useful for "daily" files that are continuously appended throughout the day
+ * and should only be marked as complete the <strong>next day</strong> at a specific time.
+ *
+ * <p>The strategy extracts the date from the filename using a regex pattern. The file is completed
+ * on the <strong>day after</strong> the date in the filename at the configured completion time.
+ * Uses the system default timezone.
+ *
+ * <h3>Example</h3>
+ * <ul>
+ *   <li>File: <code>logs-2025-12-08.log</code></li>
+ *   <li>Completion time: <code>01:00:00</code></li>
+ *   <li>File created: December 8, 2025 at 6:00 AM</li>
+ *   <li><strong>File will be completed: December 9, 2025 at 01:00:00</strong></li>
+ * </ul>
+ *
+ * <p>This ensures that all data written during the day (December 8) is collected,
+ * with a 1-hour buffer into the next day before the file is marked complete.
+ *
+ * <h3>Configuration</h3>
+ * <ul>
+ *   <li><code>completion.schedule.time</code>: Time to complete files (HH:mm:ss format, e.g., "01:00:00")</li>
+ *   <li><code>completion.schedule.date.pattern</code>:
+ *      Regex pattern to extract date from filename (default: ".*?(\\d{4}-\\d{2}-\\d{2}).*")</li>
+ *   <li><code>completion.schedule.date.format</code>: Date format in the filename (default: "yyyy-MM-dd")</li>
+ * </ul>
+ *
+ * <h3>Example filename patterns</h3>
+ * <ul>
+ *   <li><code>logs-2025-12-08.log</code> → pattern: ".*?(\\d{4}-\\d{2}-\\d{2}).*", format: "yyyy-MM-dd"</li>
+ *   <li><code>app-20251208.log</code> → pattern: ".*?(\\d{8}).*", format: "yyyyMMdd"</li>
+ * </ul>
+ */
+public class DailyCompletionStrategy implements FileCompletionStrategy, LongLivedFileReadStrategy {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DailyCompletionStrategy.class);
+
+    private LocalTime scheduledCompletionTime;
+    private Pattern datePattern;
+    private DateTimeFormatter dateFormatter;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void configure(final Map<String, ?> configs) {
+        DailyCompletionStrategyConfig config = new DailyCompletionStrategyConfig(configs);
+        this.scheduledCompletionTime = config.scheduledCompletionTime();
+        this.datePattern = config.datePattern();
+        this.dateFormatter = config.dateFormatter();
+
+        LOG.info(
+            "Configured DailyCompletionStrategy: completionTime={}, datePattern={}, dateFormat={}, timezone={}",
+            scheduledCompletionTime, datePattern.pattern(), dateFormatter, ZoneId.systemDefault()
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean shouldComplete(final FileObjectContext context) {
+        // Extract date from filename
+        LocalDate fileDate;
+        try {
+            fileDate = extractDateFromFilename(context.metadata().stringURI());
+        } catch (Exception e) {
+            LOG.warn(
+                "Could not extract date from filename '{}': {}. " +
+                    "File will not be completed until date can be determined.",
+                context.metadata().stringURI(),
+                e.getMessage()
+            );
+            // If we can't extract the date, don't complete the file
+            return false;
+        }
+
+        // Calculate when this file should be completed
+        Instant fileCompletionTime = calculateCompletionTimeForDate(fileDate);
+        Instant now = Instant.now();
+
+        boolean timeReached = now.isAfter(fileCompletionTime) || now.equals(fileCompletionTime);
+
+        if (timeReached) {
+            LOG.info(
+                "Scheduled completion time reached for file '{}' (date: {}, completion time: {}, now: {})",
+                context.metadata().stringURI(),
+                fileDate,
+                fileCompletionTime,
+                now
+            );
+        }
+
+        return timeReached;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean shouldAttemptRead(final FileObjectMeta objectMeta, final FileObjectOffset offset) {
+        // Always attempt to read if the file should be completed
+        boolean shouldRead = shouldComplete(new FileObjectContext(objectMeta))
+            || LongLivedFileReadStrategy.super.shouldAttemptRead(objectMeta, offset);
+
+        if (!shouldRead) {
+            LOG.debug("Deferring read for file '{}' until file is updated or scheduled completion time is reached.",
+                objectMeta.stringURI());
+        }
+
+        return shouldRead;
+    }
+
+    /**
+     * Extract the date from the filename using the configured pattern and format.
+     *
+     * @param filename the filename or URI
+     * @return the parsed date
+     * @throws IllegalArgumentException if the date cannot be extracted or parsed
+     */
+    private LocalDate extractDateFromFilename(String filename) {
+        Matcher matcher = datePattern.matcher(filename);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException(
+                "Filename does not match date pattern: " + filename
+            );
+        }
+
+        // Extract the date string from the first capturing group
+        String dateStr = matcher.group(1);
+
+        try {
+            return LocalDate.parse(dateStr, dateFormatter);
+        } catch (DateTimeParseException e) {
+            throw new IllegalArgumentException(
+                "Could not parse date '" + dateStr + "' from filename '" +
+                    filename + "' using format: " + dateFormatter,
+                e
+            );
+        }
+    }
+
+    /**
+     * Calculate the completion time for a given file date using the system default timezone.
+     * The completion time is the configured time on the <strong>day after</strong> the file's date.
+     *
+     * <p>For example, if the file is for 2025-12-08 and completion time is 01:00:00,
+     * the file should be completed at <strong>2025-12-09 01:00:00</strong> (in the system timezone).
+     *
+     * <p>This ensures that all data written during the file's day (Dec 8) is collected,
+     * with a buffer period into the next day before marking the file as complete.
+     *
+     * @param fileDate the date extracted from the filename
+     * @return the instant when the file should be completed
+     */
+    private Instant calculateCompletionTimeForDate(LocalDate fileDate) {
+        LocalDate completionDate = fileDate.plusDays(1);
+        LocalDateTime completionDateTime = LocalDateTime.of(completionDate, scheduledCompletionTime);
+        return completionDateTime.atZone(ZoneId.systemDefault()).toInstant();
+    }
+}

--- a/connect-file-pulse-plugin/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/EofCompletionStrategy.java
+++ b/connect-file-pulse-plugin/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/EofCompletionStrategy.java
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) StreamThoughts
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.kafka.connect.filepulse.source;
+
+/**
+ * A {@link FileCompletionStrategy} that marks files as COMPLETED
+ * immediately when they are fully read.
+ * This is the default behavior and maintains backward compatibility.
+ */
+public class EofCompletionStrategy implements FileCompletionStrategy {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean shouldComplete(final FileObjectContext context) {
+        // Complete immediately when the file is fully read
+        return true;
+    }
+}

--- a/connect-file-pulse-plugin/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/FileObjectStateReporter.java
+++ b/connect-file-pulse-plugin/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/FileObjectStateReporter.java
@@ -104,6 +104,16 @@ public class FileObjectStateReporter implements StateListener {
      * {@inheritDoc}
      */
     @Override
+    public void onPartiallyCompleted(final FileObjectContext context) {
+        Objects.requireNonNull(context, "context can't be null");
+        LOG.debug("Partially completed object-file: '{}'", context.metadata());
+        notify(context, FileObjectStatus.PARTIALLY_COMPLETED);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void onFailure(final FileObjectContext context, final Throwable t) {
         Objects.requireNonNull(context, "context can't be null");
         LOG.error("Error while processing object-file: '{}'", context.metadata(), t);

--- a/connect-file-pulse-plugin/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/FilePulseSourceConnector.java
+++ b/connect-file-pulse-plugin/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/FilePulseSourceConnector.java
@@ -119,6 +119,10 @@ public class FilePulseSourceConnector extends SourceConnector {
         final FileSystemListing<?> fileSystemListing = connectorConfig.getFileSystemListing();
         fileSystemListing.setFilter(new CompositeFileListFilter(connectorConfig.getFileSystemListingFilter()));
 
+        // Get and configure the completion strategy
+        final FileCompletionStrategy completionStrategy = connectorConfig.getFileCompletionStrategy();
+        completionStrategy.configure(connectorConfig.originalsStrings());
+
         DefaultFileSystemMonitor monitor = new DefaultFileSystemMonitor(
                 connectorConfig.allowTasksReconfigurationAfterTimeoutMs(),
                 fileSystemListing,
@@ -126,7 +130,8 @@ public class FilePulseSourceConnector extends SourceConnector {
                 connectorConfig.getFsCleanupPolicyPredicate(),
                 connectorConfig.getSourceOffsetPolicy(),
                 store,
-                connectorConfig.getTaskFilerOrder()
+                connectorConfig.getTaskFilerOrder(),
+                completionStrategy
         );
 
         monitor.setStateDefaultReadTimeout(connectorConfig.getStateDefaultReadTimeoutMs());

--- a/connect-file-pulse-plugin/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/FilePulseSourceTask.java
+++ b/connect-file-pulse-plugin/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/FilePulseSourceTask.java
@@ -151,12 +151,18 @@ public class FilePulseSourceTask extends SourceTask {
         final RecordFilterPipeline<FileRecord<TypedStruct>> filter = new DefaultRecordFilterPipeline(
                 taskConfig.filters()
         );
+
+        // Get and configure the completion strategy
+        final FileCompletionStrategy completionStrategy = taskConfig.getFileCompletionStrategy();
+        completionStrategy.configure(taskConfig.originalsStrings());
+
         return new DefaultFileRecordsPollingConsumer(
                 context,
                 taskConfig.reader(),
                 filter,
                 offsetPolicy,
-                taskConfig.isReadCommittedFile());
+                taskConfig.isReadCommittedFile(),
+                completionStrategy);
     }
 
     /**

--- a/connect-file-pulse-plugin/src/test/java/io/streamthoughts/kafka/connect/filepulse/config/DailyCompletionStrategyConfigTest.java
+++ b/connect-file-pulse-plugin/src/test/java/io/streamthoughts/kafka/connect/filepulse/config/DailyCompletionStrategyConfigTest.java
@@ -1,0 +1,311 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) StreamThoughts
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.kafka.connect.filepulse.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+import org.apache.kafka.common.config.ConfigException;
+import org.junit.Test;
+
+/**
+ * Test class for {@link DailyCompletionStrategyConfig}.
+ */
+public class DailyCompletionStrategyConfigTest {
+
+    @Test
+    public void testValidConfiguration() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_TIME_CONFIG, "01:00:00");
+        props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_DATE_PATTERN_CONFIG, ".*?(\\d{4}-\\d{2}-\\d{2}).*");
+        props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_DATE_FORMAT_CONFIG, "yyyy-MM-dd");
+
+        DailyCompletionStrategyConfig config = new DailyCompletionStrategyConfig(props);
+
+        assertNotNull(config);
+        assertEquals(LocalTime.of(1, 0, 0), config.scheduledCompletionTime());
+        assertEquals(".*?(\\d{4}-\\d{2}-\\d{2}).*", config.datePattern().pattern());
+        assertNotNull(config.dateFormatter());
+    }
+
+    @Test
+    public void testConfigurationWithDefaults() {
+        Map<String, Object> props = new HashMap<>();
+
+        DailyCompletionStrategyConfig config = new DailyCompletionStrategyConfig(props);
+
+        assertNotNull(config);
+        assertEquals(LocalTime.of(0, 1, 0), config.scheduledCompletionTime());
+        // Should use default pattern and format
+        assertNotNull(config.datePattern());
+        assertNotNull(config.dateFormatter());
+    }
+
+    @Test
+    public void testValidTimeFormats() {
+        String[] validTimes = {
+            "00:00:00",
+            "01:00:00",
+            "12:00:00",
+            "23:59:59",
+            "06:30:15"
+        };
+
+        for (String time : validTimes) {
+            Map<String, Object> props = new HashMap<>();
+            props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_TIME_CONFIG, time);
+
+            DailyCompletionStrategyConfig config = new DailyCompletionStrategyConfig(props);
+            LocalTime parsed = config.scheduledCompletionTime();
+            assertNotNull("Time should be parsed: " + time, parsed);
+        }
+    }
+
+    @Test(expected = ConfigException.class)
+    public void testInvalidTimeFormat_NoSeconds() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_TIME_CONFIG, "01:00");
+
+        DailyCompletionStrategyConfig config = new DailyCompletionStrategyConfig(props);
+        config.scheduledCompletionTime();
+    }
+
+    @Test(expected = ConfigException.class)
+    public void testInvalidTimeFormat_InvalidHour() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_TIME_CONFIG, "25:00:00");
+
+        DailyCompletionStrategyConfig config = new DailyCompletionStrategyConfig(props);
+        config.scheduledCompletionTime();
+    }
+
+    @Test(expected = ConfigException.class)
+    public void testInvalidTimeFormat_InvalidMinute() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_TIME_CONFIG, "12:60:00");
+
+        DailyCompletionStrategyConfig config = new DailyCompletionStrategyConfig(props);
+        config.scheduledCompletionTime();
+    }
+
+    @Test(expected = ConfigException.class)
+    public void testInvalidTimeFormat_InvalidSecond() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_TIME_CONFIG, "12:00:60");
+
+        DailyCompletionStrategyConfig config = new DailyCompletionStrategyConfig(props);
+        config.scheduledCompletionTime();
+    }
+
+    @Test(expected = ConfigException.class)
+    public void testInvalidTimeFormat_InvalidString() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_TIME_CONFIG, "not-a-time");
+
+        DailyCompletionStrategyConfig config = new DailyCompletionStrategyConfig(props);
+        config.scheduledCompletionTime();
+    }
+
+    @Test
+    public void testValidPatterns() {
+        String[] validPatterns = {
+            ".*?(\\d{4}-\\d{2}-\\d{2}).*",
+            ".*?(\\d{8}).*",
+            "prefix-(\\d{4})-(\\d{2})-(\\d{2})-suffix",
+            "(\\d{4})/(\\d{2})/(\\d{2})",
+            ".*"
+        };
+
+        for (String pattern : validPatterns) {
+            Map<String, Object> props = new HashMap<>();
+            props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_TIME_CONFIG, "01:00:00");
+            props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_DATE_PATTERN_CONFIG, pattern);
+
+            DailyCompletionStrategyConfig config = new DailyCompletionStrategyConfig(props);
+            Pattern compiled = config.datePattern();
+            assertNotNull("Pattern should be compiled: " + pattern, compiled);
+            assertEquals(pattern, compiled.pattern());
+        }
+    }
+
+    @Test(expected = ConfigException.class)
+    public void testInvalidPattern_UnclosedGroup() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_TIME_CONFIG, "01:00:00");
+        props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_DATE_PATTERN_CONFIG, "(\\d{4}-\\d{2}-\\d{2}");
+
+        DailyCompletionStrategyConfig config = new DailyCompletionStrategyConfig(props);
+        config.datePattern();
+    }
+
+    @Test(expected = ConfigException.class)
+    public void testInvalidPattern_InvalidRegex() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_TIME_CONFIG, "01:00:00");
+        props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_DATE_PATTERN_CONFIG, "[invalid(regex");
+
+        DailyCompletionStrategyConfig config = new DailyCompletionStrategyConfig(props);
+        config.datePattern();
+    }
+
+    @Test
+    public void testValidDateFormats() {
+        String[] validFormats = {
+            "yyyy-MM-dd",
+            "yyyyMMdd",
+            "yyyy/MM/dd",
+            "dd-MM-yyyy",
+            "MM/dd/yyyy",
+            "yyyy.MM.dd",
+            "yyyy-MM"
+        };
+
+        for (String format : validFormats) {
+            Map<String, Object> props = new HashMap<>();
+            props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_TIME_CONFIG, "01:00:00");
+            props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_DATE_FORMAT_CONFIG, format);
+
+            DailyCompletionStrategyConfig config = new DailyCompletionStrategyConfig(props);
+            DateTimeFormatter formatter = config.dateFormatter();
+            assertNotNull("Formatter should be created: " + format, formatter);
+        }
+    }
+
+    @Test(expected = ConfigException.class)
+    public void testInvalidDateFormat() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_TIME_CONFIG, "01:00:00");
+        props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_DATE_FORMAT_CONFIG, "invalid-format-xxx");
+
+        DailyCompletionStrategyConfig config = new DailyCompletionStrategyConfig(props);
+        config.dateFormatter();
+    }
+
+    @Test(expected = ConfigException.class)
+    public void testInvalidDateFormat_WrongLetters() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_TIME_CONFIG, "01:00:00");
+        props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_DATE_FORMAT_CONFIG, "yyyy-PP-dd");
+
+        DailyCompletionStrategyConfig config = new DailyCompletionStrategyConfig(props);
+        config.dateFormatter();
+    }
+
+    @Test(expected = ConfigException.class)
+    public void testInvalidDateFormat_UnknownLetter() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_TIME_CONFIG, "01:00:00");
+        props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_DATE_FORMAT_CONFIG, "xyz-abc");
+
+        DailyCompletionStrategyConfig config = new DailyCompletionStrategyConfig(props);
+        config.dateFormatter();
+    }
+
+    @Test(expected = ConfigException.class)
+    public void testInvalidDateFormat_UnmatchedBracket() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_TIME_CONFIG, "01:00:00");
+        props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_DATE_FORMAT_CONFIG, "yyyy-MM-dd]");
+
+        DailyCompletionStrategyConfig config = new DailyCompletionStrategyConfig(props);
+        config.dateFormatter();
+    }
+
+    // ========== Combined Configuration Tests ==========
+
+    @Test
+    public void testCompactDateConfiguration() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_TIME_CONFIG, "02:00:00");
+        props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_DATE_PATTERN_CONFIG, ".*?(\\d{8}).*");
+        props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_DATE_FORMAT_CONFIG, "yyyyMMdd");
+
+        DailyCompletionStrategyConfig config = new DailyCompletionStrategyConfig(props);
+
+        assertEquals(LocalTime.of(2, 0, 0), config.scheduledCompletionTime());
+        assertEquals(".*?(\\d{8}).*", config.datePattern().pattern());
+        assertNotNull(config.dateFormatter());
+    }
+
+    @Test
+    public void testSlashDateConfiguration() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_TIME_CONFIG, "03:30:00");
+        props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_DATE_PATTERN_CONFIG, ".*?(\\d{4})/(\\d{2})/(\\d{2}).*");
+        props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_DATE_FORMAT_CONFIG, "yyyy/MM/dd");
+
+        DailyCompletionStrategyConfig config = new DailyCompletionStrategyConfig(props);
+
+        assertEquals(LocalTime.of(3, 30, 0), config.scheduledCompletionTime());
+        assertEquals(".*?(\\d{4})/(\\d{2})/(\\d{2}).*", config.datePattern().pattern());
+        assertNotNull(config.dateFormatter());
+    }
+
+    @Test
+    public void testReverseDateConfiguration() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_TIME_CONFIG, "23:59:59");
+        props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_DATE_PATTERN_CONFIG, ".*?(\\d{2})-(\\d{2})-(\\d{4}).*");
+        props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_DATE_FORMAT_CONFIG, "dd-MM-yyyy");
+
+        DailyCompletionStrategyConfig config = new DailyCompletionStrategyConfig(props);
+
+        assertEquals(LocalTime.of(23, 59, 59), config.scheduledCompletionTime());
+        assertEquals(".*?(\\d{2})-(\\d{2})-(\\d{4}).*", config.datePattern().pattern());
+        assertNotNull(config.dateFormatter());
+    }
+
+    // ========== Edge Case Tests ==========
+
+    @Test
+    public void testMidnightTime() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_TIME_CONFIG, "00:00:00");
+
+        DailyCompletionStrategyConfig config = new DailyCompletionStrategyConfig(props);
+
+        assertEquals(LocalTime.MIDNIGHT, config.scheduledCompletionTime());
+    }
+
+    @Test
+    public void testEndOfDayTime() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_TIME_CONFIG, "23:59:59");
+
+        DailyCompletionStrategyConfig config = new DailyCompletionStrategyConfig(props);
+
+        assertEquals(LocalTime.of(23, 59, 59), config.scheduledCompletionTime());
+    }
+
+    @Test
+    public void testNoonTime() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_TIME_CONFIG, "12:00:00");
+
+        DailyCompletionStrategyConfig config = new DailyCompletionStrategyConfig(props);
+
+        assertEquals(LocalTime.NOON, config.scheduledCompletionTime());
+    }
+
+    @Test
+    public void testMultipleCapturingGroups() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_TIME_CONFIG, "01:00:00");
+        props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_DATE_PATTERN_CONFIG, ".*?(\\d{4})-(\\d{2})-(\\d{2}).*");
+        props.put(DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_DATE_FORMAT_CONFIG, "yyyy-MM-dd");
+
+        DailyCompletionStrategyConfig config = new DailyCompletionStrategyConfig(props);
+
+        assertNotNull(config.datePattern());
+        assertNotNull(config.dateFormatter());
+    }
+}

--- a/connect-file-pulse-plugin/src/test/java/io/streamthoughts/kafka/connect/filepulse/fs/DefaultFileSystemMonitorTest.java
+++ b/connect-file-pulse-plugin/src/test/java/io/streamthoughts/kafka/connect/filepulse/fs/DefaultFileSystemMonitorTest.java
@@ -272,8 +272,8 @@ public class DefaultFileSystemMonitorTest {
                 status -> List.of(FileObjectStatus.FAILED, FileObjectStatus.COMPLETED).contains(status),
                 OFFSET_MANAGER,
                 store,
-                TaskFileOrder.BuiltIn.LAST_MODIFIED.get()
-        );
+                TaskFileOrder.BuiltIn.LAST_MODIFIED.get(),
+                null);
     }
 
     private static class NoOpFileSystemListing implements FileSystemListing<Storage> {

--- a/connect-file-pulse-plugin/src/test/java/io/streamthoughts/kafka/connect/filepulse/source/DailyCompletionStrategyTest.java
+++ b/connect-file-pulse-plugin/src/test/java/io/streamthoughts/kafka/connect/filepulse/source/DailyCompletionStrategyTest.java
@@ -1,0 +1,266 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) StreamThoughts
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.kafka.connect.filepulse.source;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test class for {@link DailyCompletionStrategy}.
+ */
+public class DailyCompletionStrategyTest {
+
+    private DailyCompletionStrategy strategy;
+    private static final String DEFAULT_TIME = "01:00:00";
+
+    @Before
+    public void setUp() {
+        strategy = new DailyCompletionStrategy();
+    }
+
+    /**
+     * Helper method to create configuration map.
+     */
+    private Map<String, Object> createConfig(String time, String pattern, String format) {
+        Map<String, Object> config = new HashMap<>();
+        config.put("daily.completion.schedule.time", time);
+        if (pattern != null) {
+            config.put("daily.completion.schedule.date.pattern", pattern);
+        }
+        if (format != null) {
+            config.put("daily.completion.schedule.date.format", format);
+        }
+        return config;
+    }
+
+    /**
+     * Helper method to create FileObjectContext with a given filename.
+     * Uses a fixed timestamp (2024-01-15 12:00:00 UTC) for last modified time.
+     */
+    private FileObjectContext createContext(String filename) {
+        long defaultTimestamp = 1705334400000L; // 2024-01-15 12:00:00 UTC
+        GenericFileObjectMeta meta = new GenericFileObjectMeta.Builder()
+                .withUri(URI.create("file:///tmp/" + filename))
+                .withName(filename)
+                .withContentLength(1000L)
+                .withLastModified(defaultTimestamp)
+                .build();
+        return new FileObjectContext(meta);
+    }
+
+    @Test
+    public void testShouldCompleteWithStandardFilename() {
+        Map<String, Object> config = createConfig(DEFAULT_TIME, null, null);
+        strategy.configure(config);
+
+        // File from 10 days ago - should be complete
+        LocalDate tenDaysAgo = LocalDate.now().minusDays(10);
+        String filename = String.format("logs-%s.log", tenDaysAgo.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+        FileObjectContext context = createContext(filename);
+
+        assertTrue("Old file should be marked as complete",
+                   strategy.shouldComplete(context));
+    }
+
+    @Test
+    public void testShouldCompleteWithCompactDateFormat() {
+        Map<String, Object> config = createConfig("02:00:00", ".*?(\\d{8}).*", "yyyyMMdd");
+        strategy.configure(config);
+
+        // File from 10 days ago in compact format
+        LocalDate tenDaysAgo = LocalDate.now().minusDays(10);
+        String filename = String.format("app-%s.log", tenDaysAgo.format(DateTimeFormatter.ofPattern("yyyyMMdd")));
+        FileObjectContext context = createContext(filename);
+
+        // Old file should be complete
+        assertTrue("Old file with compact date should be complete",
+                   strategy.shouldComplete(context));
+    }
+
+    @Test
+    public void testShouldCompleteWithDateInMiddleOfFilename() {
+        Map<String, Object> config = createConfig(DEFAULT_TIME, null, null);
+        strategy.configure(config);
+
+        // File from 10 days ago with date in middle
+        LocalDate tenDaysAgo = LocalDate.now().minusDays(10);
+        String filename = String.format("application-%s-server.log", tenDaysAgo.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+        FileObjectContext context = createContext(filename);
+
+        assertTrue("Old file with date in middle should be complete",
+                   strategy.shouldComplete(context));
+    }
+
+    @Test
+    public void testShouldNotCompleteWhenDateCannotBeExtracted() {
+        Map<String, Object> config = createConfig(DEFAULT_TIME, null, null);
+        strategy.configure(config);
+
+        FileObjectContext context = createContext("no-date-in-filename.log");
+
+        assertFalse("Should not complete when date cannot be extracted",
+                    strategy.shouldComplete(context));
+    }
+
+    @Test
+    public void testShouldNotCompleteWhenDateFormatDoesNotMatch() {
+        Map<String, Object> config = createConfig(DEFAULT_TIME, ".*?(\\d{8}).*", "yyyyMMdd");
+        strategy.configure(config);
+
+        // Filename has yyyy-MM-dd format but config expects yyyyMMdd
+        LocalDate tenDaysAgo = LocalDate.now().minusDays(10);
+        String filename = String.format("logs-%s.log", tenDaysAgo.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+        FileObjectContext context = createContext(filename);
+
+        assertFalse("Should not complete when date format doesn't match",
+                    strategy.shouldComplete(context));
+    }
+
+    @Test
+    public void testShouldNotCompleteWhenPatternDoesNotMatch() {
+        Map<String, Object> config = createConfig(DEFAULT_TIME, "prefix-(\\d{4}-\\d{2}-\\d{2})-suffix", null);
+        strategy.configure(config);
+
+        // Filename doesn't match the strict pattern
+        LocalDate tenDaysAgo = LocalDate.now().minusDays(10);
+        String filename = String.format("logs-%s.log", tenDaysAgo.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+        FileObjectContext context = createContext(filename);
+
+        assertFalse("Should not complete when pattern doesn't match",
+                    strategy.shouldComplete(context));
+    }
+
+    @Test
+    public void testShouldCompleteForOldFile() {
+        Map<String, Object> config = createConfig("01:00:00", null, null);
+        strategy.configure(config);
+
+        // File from 10 days ago should definitely be complete
+        // (completion was 9 days ago at 01:00:00)
+        LocalDate tenDaysAgo = LocalDate.now().minusDays(10);
+        String filename = String.format("logs-%s.log", tenDaysAgo.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+        FileObjectContext context = createContext(filename);
+
+        assertTrue("Old file should be marked as complete",
+                   strategy.shouldComplete(context));
+    }
+
+    @Test
+    public void testShouldNotCompleteForFutureFile() {
+        Map<String, Object> config = createConfig("01:00:00", null, null);
+        strategy.configure(config);
+
+        // File from 5 days in the future
+        // (completion is 4 days in the future at 01:00:00)
+        LocalDate fiveDaysFromNow = LocalDate.now().plusDays(5);
+        String filename = String.format("logs-%s.log", fiveDaysFromNow.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+        FileObjectContext context = createContext(filename);
+
+        assertFalse("Future file should not be marked as complete",
+                    strategy.shouldComplete(context));
+    }
+
+
+    @Test
+    public void testFileCompletesNextDayAtScheduledTime() {
+        Map<String, Object> config = createConfig("02:00:00", null, null);
+        strategy.configure(config);
+
+        // File from today with completion time 02:00:00
+        // Should complete tomorrow at 02:00:00
+        // Since we're testing today, it should NOT be complete yet
+        LocalDate today = LocalDate.now();
+        String filename = String.format("file-%s.log", today.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+        FileObjectContext context = createContext(filename);
+
+        assertFalse("Today's file should NOT be complete (completes tomorrow at 02:00:00)",
+                    strategy.shouldComplete(context));
+    }
+
+    @Test
+    public void testShouldAttemptReadWhenFileIsComplete() {
+        Map<String, Object> config = createConfig("01:00:00", null, null);
+        strategy.configure(config);
+
+        // Old file from 10 days ago that should be complete
+        long fixedTime = 1705334400000L; // 2024-01-15 12:00:00 UTC
+        LocalDate tenDaysAgo = LocalDate.now().minusDays(10);
+        String filename = String.format("logs-%s.log", tenDaysAgo.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+
+        GenericFileObjectMeta meta = new GenericFileObjectMeta.Builder()
+                .withUri(URI.create("file:///tmp/" + filename))
+                .withName(filename)
+                .withContentLength(1000L)
+                .withLastModified(fixedTime)
+                .build();
+
+        FileObjectOffset offset = new FileObjectOffset(0, 0, fixedTime);
+
+        assertTrue("Should attempt to read when file is complete",
+                   strategy.shouldAttemptRead(meta, offset));
+    }
+
+    @Test
+    public void testShouldAttemptReadWhenFileIsModified() {
+        Map<String, Object> config = createConfig("23:59:59", null, null);
+        strategy.configure(config);
+
+        // File from 5 days in future - not complete yet but modified
+        long fileModifiedTime = 1705334400000L; // 2024-01-15 12:00:00 UTC
+        long offsetTime = 1705330800000L; // 2024-01-15 11:00:00 UTC (1 hour earlier)
+
+        LocalDate fiveDaysFromNow = LocalDate.now().plusDays(5);
+        String filename = String.format("logs-%s.log", fiveDaysFromNow.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+
+        GenericFileObjectMeta meta = new GenericFileObjectMeta.Builder()
+                .withUri(URI.create("file:///tmp/" + filename))
+                .withName(filename)
+                .withContentLength(1000L)
+                .withLastModified(fileModifiedTime)
+                .build();
+
+        // Offset from 1 hour ago - file was modified after offset
+        FileObjectOffset offset = new FileObjectOffset(0, 0, offsetTime);
+
+        assertTrue("Should attempt to read when file is modified",
+                   strategy.shouldAttemptRead(meta, offset));
+    }
+
+    @Test
+    public void testShouldNotAttemptReadWhenFileIsNotModifiedAndNotComplete() {
+        Map<String, Object> config = createConfig("23:59:59", null, null);
+        strategy.configure(config);
+
+        // File from 5 days in future - not complete yet and not modified
+        LocalDate fiveDaysFromNow = LocalDate.now().plusDays(5);
+        String filename = String.format("logs-%s.log", fiveDaysFromNow.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+
+        long fileModifiedTime = 1705330800000L; // 2024-01-15 11:00:00 UTC
+        long offsetTime = 1705334400000L; // 2024-01-15 12:00:00 UTC (newer than file)
+
+        GenericFileObjectMeta meta = new GenericFileObjectMeta.Builder()
+                .withUri(URI.create("file:///tmp/" + filename))
+                .withName(filename)
+                .withContentLength(1000L)
+                .withLastModified(fileModifiedTime)
+                .build();
+
+        // Offset is newer than last modification
+        FileObjectOffset offset = new FileObjectOffset(0, 0, offsetTime);
+
+        assertFalse("Should not attempt to read when file is not modified and not complete",
+                    strategy.shouldAttemptRead(meta, offset));
+    }
+}

--- a/docs/content/en/docs/Developer Guide/file-completion-strategies.md
+++ b/docs/content/en/docs/Developer Guide/file-completion-strategies.md
@@ -1,0 +1,87 @@
+---
+date: 2025-12-18
+title: "File Completion Strategies"
+linkTitle: "File Completion Strategies"
+weight: 95
+description: >
+  Learn how to control when files are marked as COMPLETED using pluggable completion strategies for long-lived files.
+---
+
+Connect File Pulse provides pluggable **File Completion Strategies** that control when files should be marked as COMPLETED. This feature is particularly useful for handling continuously appended files, such as daily log files or rolling data files.
+
+## Overview
+
+Previously, files were **always** marked as COMPLETED immediately when they were fully read (EOF reached). While this works well for static files, it creates challenges for files that are continuously appended, such as:
+
+- **Daily log files** that are active throughout the day
+- **Rolling files** that continue to grow until a specific time
+- **Streaming data files** where you want to process data incrementally but only mark the file complete at specific times
+
+The File Completion Strategy feature provides a pluggable architecture that allows you to customize when files should be marked as COMPLETED.
+
+## Configuration
+
+The completion strategy can be configured with the following connect property:
+
+| Configuration                      | Description                                                                                    | Type    | Default                                                                         | Importance |
+|------------------------------------|------------------------------------------------------------------------------------------------|---------|---------------------------------------------------------------------------------|------------|
+| `fs.completion.strategy.class`     | The fully qualified name of the class which determines when files should be marked as COMPLETED | class   | `io.streamthoughts.kafka.connect.filepulse.source.EofCompletionStrategy`      | high       |
+
+## Available Strategies
+
+### 1. EofCompletionStrategy (Default)
+
+**Behavior**: Marks files as COMPLETED immediately when they are fully read (End-of-File reached).
+
+**Use Case**: Static files that don't change once created or where you want the traditional immediate completion behavior.
+
+**Configuration**: This is the default behavior. You can explicitly configure it or simply omit the configuration.
+
+```json
+{
+  "fs.completion.strategy.class": "io.streamthoughts.kafka.connect.filepulse.source.EofCompletionStrategy"
+}
+```
+
+**Characteristics**:
+- ✅ Simple and predictable behavior
+- ✅ Immediate file completion upon reading all content
+- ✅ Suitable for batch processing of static files
+
+---
+
+### 2. DailyCompletionStrategy
+
+**Purpose**: Mark files as COMPLETED at a scheduled time on the day **after** the file date by extracting the date from the filename.
+
+**Use Case**: Daily log files that are continuously appended throughout the day and should only be marked as complete the next day at a specific time (e.g., 1 AM the next day).
+
+**Important**: This strategy is designed specifically for daily files where the date in the filename represents that specific day. The file will be completed the **next day** at the scheduled time to ensure all data for that day is collected.
+
+#### Configuration
+
+| Configuration                          | Description                                                                      | Type     | Default                   | Importance |
+|----------------------------------------|----------------------------------------------------------------------------------|----------|---------------------------|------------|
+| `daily.completion.schedule.time`       | The time of day to complete files (format: HH:mm:ss)                            | string   | `00:01:00`                | high       |
+| `daily.completion.schedule.date.pattern` | Regex pattern to extract date from filename (must contain one capturing group)   | string   | `.*?(\d{4}-\d{2}-\d{2}).*` | high       |
+| `daily.completion.schedule.date.format` | Date format pattern for parsing the extracted date                              | string   | `yyyy-MM-dd`              | high       |
+
+**Note**: The strategy uses the system default timezone
+
+#### Example Configuration
+
+```json
+{
+  "name": "daily-logs-connector",
+  "connector.class": "io.streamthoughts.kafka.connect.filepulse.source.FilePulseSourceConnector",
+  "fs.listing.class": "io.streamthoughts.kafka.connect.filepulse.fs.LocalFSDirectoryListing",
+  "fs.listing.directory.path": "/logs",
+  "fs.listing.filters": "io.streamthoughts.kafka.connect.filepulse.fs.filter.RegexFileListFilter",
+  "file.filter.regex.pattern": "app-\\d{4}-\\d{2}-\\d{2}\\.log",
+  
+  "fs.completion.strategy.class": "io.streamthoughts.kafka.connect.filepulse.source.DailyCompletionStrategy",
+  "daily.completion.schedule.time": "01:00:00",
+  "daily.completion.schedule.date.pattern": ".*?(\\d{4}-\\d{2}-\\d{2}).*",
+  "daily.completion.schedule.date.format": "yyyy-MM-dd"
+}
+```


### PR DESCRIPTION
## 🎯 Overview

This PR introduces a new **file completion strategy** system that allows users to control when files should be marked as `COMPLETED`, addressing the limitations of the previous immediate completion on EOF behavior. This is particularly valuable for long-lived, continuously appended files such as daily log files.

## 💡 Motivation

### Problem

Previously, Kafka Connect File Pulse would always mark files as `COMPLETED` immediately when they were fully read (EOF reached). While this works perfectly for static files, it creates significant challenges for continuously appended files:

1. **Daily/Rolling Files**: Files that are written throughout the day (e.g., `app-2025-12-08.log`) would be marked complete as soon as they're first read, preventing the connector from reading additional data appended later
2. **Streaming Data Files**: Files receiving real-time data streams would be completed prematurely
3. **No Control**: Users had no way to specify custom completion logic based on their use case

### Solution

I have implemented a strategy pattern that allows users to:
- Configure different completion strategies based on their use case
- Implement custom completion logic without modifying core connector code
- Maintain full backward compatibility with existing configurations

## 🏗️ Architecture

### New Components

#### 1. `FileCompletionStrategy` Interface (API)
**Location**: `connect-file-pulse-api/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/FileCompletionStrategy.java`

Core strategy interface that defines:
```java
public interface FileCompletionStrategy {
    void configure(Map<String, ?> configs);
    boolean shouldComplete(FileObjectContext context);
}
```

#### 2. `LongLivedFileReadStrategy` Interface (API)
**Location**: `connect-file-pulse-api/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/LongLivedFileReadStrategy.java`

Optional interface for strategies managing long-lived files:
```java
public interface LongLivedFileReadStrategy {
    boolean shouldAttemptRead(FileObjectMeta objectMeta, FileObjectOffset offset);
}
```

This interface enables read deferral - strategies can signal to the connector when NOT to attempt reading a file (e.g., when no new data is expected), avoiding unnecessary polling and timeouts while still allowing eventual completion.

#### 3. `EofCompletionStrategy` (Default)
**Location**: `connect-file-pulse-plugin/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/EofCompletionStrategy.java`

Default implementation that maintains **100% backward compatibility**:
- Marks files as `COMPLETED` immediately when fully read
- No-configuration required
- Optimal for static files

#### 4. `DailyCompletionStrategy`
**Location**: `connect-file-pulse-plugin/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/DailyCompletionStrategy.java`

New strategy for daily files that:
- Extracts the date from the filename using a regex pattern
- Schedules completion for the **next day** at a configured time

**Example**:
- File: `logs-2025-12-08.log` (created Dec 8, 2025 at 6:00 AM)
- Completion time: `01:00:00`
- **Completion scheduled for**: December 9, 2025 at 01:00:00
- **Benefit**: Captures all data written during Dec 8, plus a 1-hour buffer period

#### 5. `DailyCompletionStrategyConfig`
**Location**: `connect-file-pulse-plugin/src/main/java/io/streamthoughts/kafka/connect/filepulse/config/DailyCompletionStrategyConfig.java`

Configuration class with validators for:
- `daily.completion.schedule.time`: Time in HH:mm:ss format (default: `00:01:00`)
- `daily.completion.schedule.date.pattern`: Regex to extract date (default: `.*?(\\d{4}-\\d{2}-\\d{2}).*`)
- `daily.completion.schedule.date.format`: Date format pattern (default: `yyyy-MM-dd`)

### Modified Components

#### 1. `CommonSourceConfig`
- Added `FS_COMPLETION_STRATEGY_CLASS_CONFIG` configuration property
- Default value: `EofCompletionStrategy.class` (backward compatible)
- Added `getFileCompletionStrategy()` method to instantiate configured strategy

#### 2. `DefaultFileRecordsPollingConsumer`
- Integrated `FileCompletionStrategy` into the polling logic
- Uses strategy's `shouldComplete()` to determine when to mark files as `COMPLETED`

#### 3. `DefaultFileSystemMonitor`
- Integrated `LongLivedFileReadStrategy` support
- Filters files based on `shouldAttemptRead()` to avoid unnecessary polling

#### 4. `FilePulseSourceTask` & `FilePulseSourceConnector`
- Configure and pass `FileCompletionStrategy` to consumer
- Ensure proper initialization and configuration propagation

## 🔄 Backward Compatibility

### 100% Backward Compatible 

- **Default behavior unchanged**: Existing connectors will continue to use `EofCompletionStrategy` (immediate completion)
- **No configuration changes required**: Users don't need to modify existing configurations
- **No breaking API changes**: All existing interfaces and classes remain unchanged

### Migration Path

Existing configurations continue to work as-is:
```json
{
  "name": "my-existing-connector",
  "connector.class": "io.streamthoughts.kafka.connect.filepulse.source.FilePulseSourceConnector"
  // No fs.completion.strategy.class specified = uses EofCompletionStrategy (default)
}
```

To adopt new functionality, simply add the configuration:
```json
{
  "name": "my-connector",
  "connector.class": "io.streamthoughts.kafka.connect.filepulse.source.FilePulseSourceConnector",
  "fs.completion.strategy.class": "io.streamthoughts.kafka.connect.filepulse.source.DailyCompletionStrategy",
  "daily.completion.schedule.time": "01:00:00",
  "daily.completion.schedule.date.pattern": ".*?(\\d{4}-\\d{2}-\\d{2}).*",
  "daily.completion.schedule.date.format": "yyyy-MM-dd"
}
```

## 📋 Configuration

### Common Configuration

| Property | Description | Default | Importance |
|----------|-------------|---------|------------|
| `fs.completion.strategy.class` | FileCompletionStrategy class to use | `EofCompletionStrategy` | MEDIUM |

### DailyCompletionStrategy Configuration

| Property | Description | Default | Importance |
|----------|-------------|---------|------------|
| `daily.completion.schedule.time` | Time to complete files (HH:mm:ss) | `00:01:00` | HIGH |
| `daily.completion.schedule.date.pattern` | Regex to extract date from filename | `.*?(\\d{4}-\\d{2}-\\d{2}).*` | HIGH |
| `daily.completion.schedule.date.format` | Date format pattern for parsing | `yyyy-MM-dd` | HIGH |

## 🎯 Use Cases

### Use Case 1: Daily Log Files
**Scenario**: Application writes to `app-2025-12-08.log` throughout December 8th. You want to continuously read new data but only mark the file complete at 1 AM on December 9th.

**Configuration**:
```json
{
  "fs.completion.strategy.class": "io.streamthoughts.kafka.connect.filepulse.source.DailyCompletionStrategy",
  "daily.completion.schedule.time": "01:00:00",
  "daily.completion.schedule.date.pattern": ".*?(\\d{4}-\\d{2}-\\d{2}).*",
  "daily.completion.schedule.date.format": "yyyy-MM-dd"
}
```

### Use Case 2: Static Files (Backward Compatible)
**Scenario**: Standard file ingestion - complete files immediately when fully read.

**Configuration**: None needed (default behavior).

### Use Case 3: Custom Completion Logic
**Scenario**: Implement your own completion strategy based on file size, record count, external triggers, etc.

**Implementation**: Implement `FileCompletionStrategy` interface and configure your custom class.


## 🚀 Benefits

1. **Flexibility**: Users can choose the right completion strategy for their use case
2. **Extensibility**: Easy to implement custom strategies without modifying core code
3. **Efficiency**: `LongLivedFileReadStrategy` reduces unnecessary polling and resource usage
4. **Backward Compatible**: Zero impact on existing deployments
