### PR TITLE
fix(filesystems): handle SMB directory path without trailing slash

### DIFF
--- a/connect-file-pulse-filesystems/filepulse-smb-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/client/SmbClient.java
+++ b/connect-file-pulse-filesystems/filepulse-smb-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/client/SmbClient.java
@@ -94,7 +94,7 @@ public class SmbClient {
      * List files in the specified directory.
      */
     public Stream<FileObjectMeta> listFiles(String directoryPath) {
-        String smbUrl = baseUrl + (directoryPath.startsWith("/") ? directoryPath.substring(1) : directoryPath);
+        String smbUrl = buildDirectoryUrl(directoryPath);
 
         return executeWithRetry(() -> {
             LOG.debug("Listing files in SMB directory: {}", smbUrl);
@@ -118,6 +118,21 @@ public class SmbClient {
                         .map(this::buildFileMetadata);
             }
         });
+    }
+
+    /**
+     * Builds the full SMB directory URL from the configured base URL and the given directory path.
+     * <p>
+     * The leading slash is stripped from {@code directoryPath} (since {@code baseUrl} already ends
+     * with {@code /}), and a trailing slash is appended when missing so that jcifs treats the path
+     * as a directory and constructs correct child file URIs
+     */
+    String buildDirectoryUrl(String directoryPath) {
+        String normalizedPath = directoryPath.startsWith("/") ? directoryPath.substring(1) : directoryPath;
+        if (!normalizedPath.isEmpty() && !normalizedPath.endsWith("/")) {
+            normalizedPath = normalizedPath + "/";
+        }
+        return baseUrl + normalizedPath;
     }
 
     /**

--- a/connect-file-pulse-filesystems/filepulse-smb-fs/src/test/java/io/streamthoughts/kafka/connect/filepulse/fs/client/SmbClientTest.java
+++ b/connect-file-pulse-filesystems/filepulse-smb-fs/src/test/java/io/streamthoughts/kafka/connect/filepulse/fs/client/SmbClientTest.java
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) StreamThoughts
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.kafka.connect.filepulse.fs.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.streamthoughts.kafka.connect.filepulse.fs.SmbFileSystemListingConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SmbClientTest {
+
+    private SmbClient smbClient;
+
+    @BeforeEach
+    void setUp() {
+        SmbFileSystemListingConfig config = mock(SmbFileSystemListingConfig.class);
+        // Needed by buildBaseUrl()
+        when(config.getSmbHost()).thenReturn("samba");
+        when(config.getSmbShare()).thenReturn("kafka-sink");
+        // Needed by createCifsContext()
+        when(config.getSmbMaxVersion()).thenReturn("SMB311");
+        when(config.getResponseTimeout()).thenReturn(35000);
+        when(config.getConnectionTimeout()).thenReturn(35000);
+        when(config.getSoTimeout()).thenReturn(35000);
+        when(config.getSmbDomain()).thenReturn("WORKGROUP");
+        when(config.getSmbUser()).thenReturn("user");
+        when(config.getSmbPassword()).thenReturn("password");
+
+        smbClient = new SmbClient(config);
+    }
+
+    @Test
+    void buildDirectoryUrl_should_return_base_url_when_directory_path_is_root() {
+        assertThat(smbClient.buildDirectoryUrl("/"))
+                .isEqualTo("smb://samba/kafka-sink/");
+    }
+
+    @Test
+    void buildDirectoryUrl_should_return_base_url_when_directory_path_is_empty() {
+        assertThat(smbClient.buildDirectoryUrl(""))
+                .isEqualTo("smb://samba/kafka-sink/");
+    }
+
+    @Test
+    void buildDirectoryUrl_should_handle_nested_subdirectory_without_trailing_slash() {
+        assertThat(smbClient.buildDirectoryUrl("/input/orders/2025"))
+            .isEqualTo("smb://samba/kafka-sink/input/orders/2025/");
+    }
+
+    @Test
+    void buildDirectoryUrl_should_handle_nested_subdirectory() {
+        assertThat(smbClient.buildDirectoryUrl("/input/orders/2025/"))
+            .isEqualTo("smb://samba/kafka-sink/input/orders/2025/");
+    }
+
+    @Test
+    void buildDirectoryUrl_should_handle_path_without_leading_and_trailing_slash() {
+        assertThat(smbClient.buildDirectoryUrl("input/orders/2025"))
+                .isEqualTo("smb://samba/kafka-sink/input/orders/2025/");
+    }
+}


### PR DESCRIPTION
Fix #744

Handle `smb.listing.directory.path` with or without trailing slash + add tests