### PR TITLE
Improve completion strategies by providing daily, weekly and monthly by default

### DIFF
--- a/connect-file-pulse-plugin/src/main/java/io/streamthoughts/kafka/connect/filepulse/config/DailyCompletionStrategyConfig.java
+++ b/connect-file-pulse-plugin/src/main/java/io/streamthoughts/kafka/connect/filepulse/config/DailyCompletionStrategyConfig.java
@@ -6,202 +6,124 @@
  */
 package io.streamthoughts.kafka.connect.filepulse.config;
 
+import io.streamthoughts.kafka.connect.filepulse.source.CompletionPeriod;
 import io.streamthoughts.kafka.connect.filepulse.source.DailyCompletionStrategy;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
-import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.common.config.ConfigException;
 
 /**
  * Configuration for {@link DailyCompletionStrategy}.
+ *
+ * <p><strong>Deprecated.</strong> Use {@link ScheduledCompletionStrategyConfig} instead,
+ * which supports {@code DAILY}, {@code WEEKLY} and {@code MONTHLY} periods.
+ *
+ * <p>This class accepts the legacy {@code daily.completion.schedule.*} config keys and
+ * translates them to the canonical {@code completion.schedule.*} keys understood by
+ * {@link ScheduledCompletionStrategyConfig}.
+ *
+ * <h3>Key mapping</h3>
+ * <ul>
+ *   <li>{@code daily.completion.schedule.time}         → {@code completion.schedule.time}</li>
+ *   <li>{@code daily.completion.schedule.date.pattern} → {@code completion.schedule.date.pattern}</li>
+ *   <li>{@code daily.completion.schedule.date.format}  → {@code completion.schedule.date.format}</li>
+ * </ul>
+ *
+ * @deprecated Use {@link ScheduledCompletionStrategyConfig} with {@code completion.schedule.period=DAILY}.
  */
-public class DailyCompletionStrategyConfig extends AbstractConfig {
+@Deprecated
+public class DailyCompletionStrategyConfig extends ScheduledCompletionStrategyConfig {
 
+    /** @deprecated Use {@link ScheduledCompletionStrategyConfig#COMPLETION_SCHEDULE_TIME_CONFIG}. */
+    @Deprecated
     public static final String COMPLETION_SCHEDULE_TIME_CONFIG = "daily.completion.schedule.time";
-    private static final String COMPLETION_SCHEDULE_TIME_DOC =
-        "Time to complete files in HH:mm:ss format (e.g., '00:01:00'). " +
-        "Files will be marked as COMPLETED when the current time passes this scheduled time " +
-        "for the date extracted from the filename. Uses the system default timezone.";
-    private static final String COMPLETION_SCHEDULE_TIME_DEFAULT = "00:01:00";
 
+    /** @deprecated Use {@link ScheduledCompletionStrategyConfig#COMPLETION_SCHEDULE_DATE_PATTERN_CONFIG}. */
+    @Deprecated
     public static final String COMPLETION_SCHEDULE_DATE_PATTERN_CONFIG = "daily.completion.schedule.date.pattern";
-    private static final String COMPLETION_SCHEDULE_DATE_PATTERN_DOC =
-        "Regex pattern to extract date from filename. The pattern should contain capturing groups " +
-        "that match the date components. For example: '.*?(\\d{4}-\\d{2}-\\d{2}).*' to match dates " +
-        "like '2025-12-08' in filenames like 'logs-2025-12-08.log'.";
-    private static final String COMPLETION_SCHEDULE_DATE_PATTERN_DEFAULT = ".*?(\\d{4}-\\d{2}-\\d{2}).*";
 
+    /** @deprecated Use {@link ScheduledCompletionStrategyConfig#COMPLETION_SCHEDULE_DATE_FORMAT_CONFIG}. */
+    @Deprecated
     public static final String COMPLETION_SCHEDULE_DATE_FORMAT_CONFIG = "daily.completion.schedule.date.format";
-    private static final String COMPLETION_SCHEDULE_DATE_FORMAT_DOC =
-        "Date format pattern used to parse the date extracted from the filename. " +
-        "Must match the date format in the filename (e.g., 'yyyy-MM-dd' for '2025-12-08', " +
-        "'yyyyMMdd' for '20251208'). See Java DateTimeFormatter for supported patterns.";
-    private static final String COMPLETION_SCHEDULE_DATE_FORMAT_DEFAULT = "yyyy-MM-dd";
 
     /**
      * Creates a new {@link DailyCompletionStrategyConfig} instance.
      *
-     * @param originals the configuration properties
+     * <p>Accepts legacy {@code daily.completion.schedule.*} keys and translates them to the
+     * canonical {@code completion.schedule.*} keys before delegating to
+     * {@link ScheduledCompletionStrategyConfig}.
+     *
+     * @param originals the configuration properties.
      */
     public DailyCompletionStrategyConfig(final Map<?, ?> originals) {
-        super(configDef(), originals);
+        super(translate(originals));
     }
 
-    /**
-     * Get the scheduled completion time.
-     *
-     * @return the time at which files should be completed
-     */
+    /** {@inheritDoc} */
+    @Override
     public LocalTime scheduledCompletionTime() {
-        String timeStr = getString(COMPLETION_SCHEDULE_TIME_CONFIG);
-        try {
-            return LocalTime.parse(timeStr, DateTimeFormatter.ofPattern("HH:mm:ss"));
-        } catch (DateTimeParseException e) {
-            throw new ConfigException(
-                COMPLETION_SCHEDULE_TIME_CONFIG,
-                timeStr,
-                "Invalid time format. Expected format: HH:mm:ss (e.g., '23:59:59')"
-            );
-        }
+        return super.scheduledCompletionTime();
     }
 
-    /**
-     * Get the compiled regex pattern for extracting dates from filenames.
-     *
-     * @return the compiled pattern
-     */
+    /** {@inheritDoc} */
+    @Override
     public Pattern datePattern() {
-        String patternStr = getString(COMPLETION_SCHEDULE_DATE_PATTERN_CONFIG);
-        try {
-            return Pattern.compile(patternStr);
-        } catch (PatternSyntaxException e) {
-            throw new ConfigException(
-                COMPLETION_SCHEDULE_DATE_PATTERN_CONFIG,
-                patternStr,
-                "Invalid regex pattern: " + e.getMessage()
-            );
-        }
+        return super.datePattern();
     }
 
-    /**
-     * Get the date formatter for parsing dates from filenames.
-     *
-     * @return the date formatter
-     */
+    /** {@inheritDoc} */
+    @Override
     public DateTimeFormatter dateFormatter() {
-        String formatStr = getString(COMPLETION_SCHEDULE_DATE_FORMAT_CONFIG);
-        try {
-            return DateTimeFormatter.ofPattern(formatStr);
-        } catch (IllegalArgumentException e) {
-            throw new ConfigException(
-                COMPLETION_SCHEDULE_DATE_FORMAT_CONFIG,
-                formatStr,
-                "Invalid date format pattern: " + e.getMessage()
-            );
-        }
+        return super.dateFormatter();
     }
 
     /**
-     * Define the configuration.
+     * Returns the {@link ConfigDef} that accepts both the legacy {@code daily.*} keys
+     * and the new {@code completion.schedule.*} keys.
      *
-     * @return the configuration definition
+     * @return the config definition.
+     * @deprecated Use {@link ScheduledCompletionStrategyConfig#configDef()}.
      */
+    @Deprecated
     public static ConfigDef configDef() {
-        return new ConfigDef()
-            .define(
-                COMPLETION_SCHEDULE_TIME_CONFIG,
-                ConfigDef.Type.STRING,
-                COMPLETION_SCHEDULE_TIME_DEFAULT,
-                new TimeValidator(),
-                ConfigDef.Importance.HIGH,
-                COMPLETION_SCHEDULE_TIME_DOC
-            )
-            .define(
-                COMPLETION_SCHEDULE_DATE_PATTERN_CONFIG,
-                ConfigDef.Type.STRING,
-                COMPLETION_SCHEDULE_DATE_PATTERN_DEFAULT,
-                new RegexValidator(),
-                ConfigDef.Importance.HIGH,
-                COMPLETION_SCHEDULE_DATE_PATTERN_DOC
-            )
-            .define(
-                COMPLETION_SCHEDULE_DATE_FORMAT_CONFIG,
-                ConfigDef.Type.STRING,
-                COMPLETION_SCHEDULE_DATE_FORMAT_DEFAULT,
-                new DateFormatValidator(),
-                ConfigDef.Importance.HIGH,
-                COMPLETION_SCHEDULE_DATE_FORMAT_DOC
-            );
+        return ScheduledCompletionStrategyConfig.configDef();
     }
 
     /**
-     * Validator for time format (HH:mm:ss).
+     * Translates a map that may contain legacy {@code daily.completion.schedule.*} keys
+     * into a map with the canonical {@code completion.schedule.*} keys.
+     *
+     * @param originals the original configuration map (may be typed with any key type).
+     * @return a new map with translated keys.
      */
-    private static class TimeValidator implements ConfigDef.Validator {
-        @Override
-        public void ensureValid(String name, Object value) {
-            if (value == null) {
-                throw new ConfigException(name, value, "Time configuration is required");
-            }
-            String timeStr = value.toString();
-            try {
-                LocalTime.parse(timeStr, DateTimeFormatter.ofPattern("HH:mm:ss"));
-            } catch (DateTimeParseException e) {
-                throw new ConfigException(
-                    name,
-                    value,
-                    "Invalid time format. Expected format: HH:mm:ss (e.g., '23:59:59')"
-                );
-            }
-        }
-    }
+    private static Map<String, Object> translate(final Map<?, ?> originals) {
+        Map<String, Object> translated = new HashMap<>(originals.size() + 1);
 
-    /**
-     * Validator for regex pattern.
-     */
-    private static class RegexValidator implements ConfigDef.Validator {
-        @Override
-        public void ensureValid(String name, Object value) {
-            if (value == null) {
-                return; // Has default value
+        originals.forEach((rawKey, value) -> {
+            String key = rawKey.toString();
+            final String mappedKey;
+            switch (key) {
+                case COMPLETION_SCHEDULE_TIME_CONFIG:
+                    mappedKey = ScheduledCompletionStrategyConfig.COMPLETION_SCHEDULE_TIME_CONFIG;
+                    break;
+                case COMPLETION_SCHEDULE_DATE_PATTERN_CONFIG:
+                    mappedKey = ScheduledCompletionStrategyConfig.COMPLETION_SCHEDULE_DATE_PATTERN_CONFIG;
+                    break;
+                case COMPLETION_SCHEDULE_DATE_FORMAT_CONFIG:
+                    mappedKey = ScheduledCompletionStrategyConfig.COMPLETION_SCHEDULE_DATE_FORMAT_CONFIG;
+                    break;
+                default:
+                    mappedKey = key;
             }
-            String patternStr = value.toString();
-            try {
-                Pattern.compile(patternStr);
-            } catch (PatternSyntaxException e) {
-                throw new ConfigException(
-                    name,
-                    value,
-                    "Invalid regex pattern: " + e.getMessage()
-                );
-            }
-        }
-    }
+            translated.putIfAbsent(mappedKey, value);
+        });
 
-    /**
-     * Validator for date format pattern.
-     */
-    private static class DateFormatValidator implements ConfigDef.Validator {
-        @Override
-        public void ensureValid(String name, Object value) {
-            if (value == null) {
-                return; // Has default value
-            }
-            String formatStr = value.toString();
-            try {
-                DateTimeFormatter.ofPattern(formatStr);
-            } catch (IllegalArgumentException e) {
-                throw new ConfigException(
-                    name,
-                    value,
-                    "Invalid date format pattern. Use a valid DateTimeFormatter pattern (e.g., 'yyyy-MM-dd')"
-                );
-            }
-        }
+        translated.put(ScheduledCompletionStrategyConfig.COMPLETION_SCHEDULE_PERIOD_CONFIG,
+            CompletionPeriod.DAILY.name());
+
+        return translated;
     }
 }

--- a/connect-file-pulse-plugin/src/main/java/io/streamthoughts/kafka/connect/filepulse/config/ScheduledCompletionStrategyConfig.java
+++ b/connect-file-pulse-plugin/src/main/java/io/streamthoughts/kafka/connect/filepulse/config/ScheduledCompletionStrategyConfig.java
@@ -1,0 +1,357 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) StreamThoughts
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.kafka.connect.filepulse.config;
+
+import io.streamthoughts.kafka.connect.filepulse.source.CompletionPeriod;
+import io.streamthoughts.kafka.connect.filepulse.source.ScheduledCompletionStrategy;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+
+/**
+ * Configuration for {@link ScheduledCompletionStrategy}.
+ *
+ * <h3>Configuration keys</h3>
+ * <ul>
+ *   <li>{@code completion.schedule.time}         – Time-of-day (HH:mm:ss) at which the file is completed.</li>
+ *   <li>{@code completion.schedule.date.pattern} – Regex with one capturing group for the date in the filename.</li>
+ *   <li>{@code completion.schedule.date.format}  – {@link DateTimeFormatter} pattern for that date.</li>
+ *   <li>{@code completion.schedule.period}       – {@link CompletionPeriod}: {@code DAILY} (default),
+ *       {@code WEEKLY}, or {@code MONTHLY}.</li>
+ *   <li>{@code completion.schedule.week.start.day} – First day of the week for {@code WEEKLY} period
+ *       when no day field is present in the format (default: {@code MONDAY}).</li>
+ * </ul>
+ */
+public class ScheduledCompletionStrategyConfig extends AbstractConfig {
+
+    public static final String COMPLETION_SCHEDULE_TIME_CONFIG = "completion.schedule.time";
+    private static final String COMPLETION_SCHEDULE_TIME_DOC =
+        "Time of day (HH:mm:ss) at which the file is marked as COMPLETED after the period boundary " +
+        "computed from the date extracted from the filename. Uses the system default timezone.";
+    private static final String COMPLETION_SCHEDULE_TIME_DEFAULT = "00:01:00";
+
+    public static final String COMPLETION_SCHEDULE_DATE_PATTERN_CONFIG = "completion.schedule.date.pattern";
+    private static final String COMPLETION_SCHEDULE_DATE_PATTERN_DOC =
+        "Regex pattern used to extract the date from the filename. Must contain exactly one capturing group " +
+        "that matches the date portion. " +
+        "Example: '.*?(\\d{4}-\\d{2}-\\d{2}).*' matches dates like '2025-12-08' in 'logs-2025-12-08.log'.";
+    private static final String COMPLETION_SCHEDULE_DATE_PATTERN_DEFAULT = ".*?(\\d{4}-\\d{2}-\\d{2}).*";
+
+    public static final String COMPLETION_SCHEDULE_DATE_FORMAT_CONFIG = "completion.schedule.date.format";
+    private static final String COMPLETION_SCHEDULE_DATE_FORMAT_DOC =
+        "DateTimeFormatter pattern used to parse the date captured from the filename. " +
+        "Must match the format captured by the regex group (e.g. 'yyyy-MM-dd' for '2025-12-08', " +
+        "'yyyyMMdd' for '20251208').";
+    private static final String COMPLETION_SCHEDULE_DATE_FORMAT_DEFAULT = "yyyy-MM-dd";
+
+    public static final String COMPLETION_SCHEDULE_PERIOD_CONFIG = "completion.schedule.period";
+    private static final String COMPLETION_SCHEDULE_PERIOD_DOC =
+        "Period unit that controls when the file is completed relative to the date in its filename. " +
+        "Accepted values: DAILY (complete the day after), WEEKLY (complete the next configured week start day), " +
+        "MONTHLY (complete on the 1st day of the next month). Default: DAILY.";
+    private static final String COMPLETION_SCHEDULE_PERIOD_DEFAULT = CompletionPeriod.DAILY.name();
+
+    public static final String COMPLETION_SCHEDULE_WEEK_START_DAY_CONFIG = "completion.schedule.week.start.day";
+    private static final String COMPLETION_SCHEDULE_WEEK_START_DAY_DOC =
+        "The first day of the week, used when no day field is present in the date format (WEEKLY period only). " +
+        "Accepted values: MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY. Default: MONDAY.";
+    private static final String COMPLETION_SCHEDULE_WEEK_START_DAY_DEFAULT = "MONDAY";
+
+    /**
+     * Creates a new {@link ScheduledCompletionStrategyConfig} instance.
+     *
+     * @param originals the configuration properties.
+     */
+    public ScheduledCompletionStrategyConfig(final Map<?, ?> originals) {
+        super(configDef(), originals);
+    }
+
+    /**
+     * Returns the scheduled completion time of day.
+     *
+     * @return the parsed {@link LocalTime}.
+     */
+    public LocalTime scheduledCompletionTime() {
+        String timeStr = getString(COMPLETION_SCHEDULE_TIME_CONFIG);
+        try {
+            return LocalTime.parse(timeStr, DateTimeFormatter.ofPattern("HH:mm:ss"));
+        } catch (DateTimeParseException e) {
+            throw new ConfigException(
+                COMPLETION_SCHEDULE_TIME_CONFIG,
+                timeStr,
+                "Invalid time format. Expected format: HH:mm:ss (e.g., '23:59:59')"
+            );
+        }
+    }
+
+    /**
+     * Returns the compiled regex {@link Pattern} used to extract the date from filenames.
+     *
+     * @return the compiled pattern.
+     */
+    public Pattern datePattern() {
+        String patternStr = getString(COMPLETION_SCHEDULE_DATE_PATTERN_CONFIG);
+        try {
+            return Pattern.compile(patternStr);
+        } catch (PatternSyntaxException e) {
+            throw new ConfigException(
+                COMPLETION_SCHEDULE_DATE_PATTERN_CONFIG,
+                patternStr,
+                "Invalid regex pattern: " + e.getMessage()
+            );
+        }
+    }
+
+    /**
+     * Returns a base {@link DateTimeFormatter} built from the configured pattern, with structural
+     * field defaults that do not depend on the current date:
+     * <ul>
+     *   <li>{@link CompletionPeriod#WEEKLY} – defaults {@code DAY_OF_WEEK} to the configured
+     *       {@link #weekStartDay()} if no day field is present.</li>
+     *   <li>{@link CompletionPeriod#MONTHLY} – defaults {@code DAY_OF_MONTH} to 1 if no day field
+     *       is present.</li>
+     * </ul>
+     *
+     * <p>Date-relative defaults ({@code WEEK_BASED_YEAR}, {@code YEAR}) are intentionally <em>not</em>
+     * applied here — they must be injected fresh at each parse call in
+     * {@link io.streamthoughts.kafka.connect.filepulse.source.ScheduledCompletionStrategy}
+     * so that {@code LocalDate.now()} always reflects the actual current date, even across year
+     * boundaries without a connector restart.
+     *
+     * @return the base date formatter.
+     * @throws ConfigException if the pattern is invalid.
+     */
+    public DateTimeFormatter dateFormatter() {
+        String formatStr = getString(COMPLETION_SCHEDULE_DATE_FORMAT_CONFIG);
+        CompletionPeriod period = completionPeriod();
+        try {
+            DateTimeFormatterBuilder builder = new DateTimeFormatterBuilder();
+
+            switch (period) {
+                case WEEKLY:
+                    // Default DAY_OF_WEEK to the configured week start day if no explicit day field is present
+                    if (!formatStr.contains("d") && !formatStr.contains("e") && !formatStr.contains("E")) {
+                        builder.parseDefaulting(ChronoField.DAY_OF_WEEK, weekStartDay().getValue());
+                    }
+                    break;
+                case MONTHLY:
+                    // Default DAY_OF_MONTH to 1 if no explicit day field is present
+                    if (!formatStr.contains("d")) {
+                        builder.parseDefaulting(ChronoField.DAY_OF_MONTH, 1);
+                    }
+                    break;
+                default:
+                    break;
+            }
+
+            return builder.appendPattern(formatStr).toFormatter();
+        } catch (IllegalArgumentException e) {
+            throw new ConfigException(
+                COMPLETION_SCHEDULE_DATE_FORMAT_CONFIG,
+                formatStr,
+                "Invalid date format pattern: " + e.getMessage()
+            );
+        }
+    }
+
+    /**
+     * Returns {@code true} if the configured date format contains no year field ({@code Y} or {@code y})
+     * and the period is {@link CompletionPeriod#WEEKLY}.
+     *
+     * <p>When {@code true}, {@code WEEK_BASED_YEAR} must be injected fresh at each parse call.
+     *
+     * @return {@code true} if a fresh week-based year default must be applied at parse time.
+     */
+    public boolean requiresWeekBasedYearDefault() {
+        if (completionPeriod() != CompletionPeriod.WEEKLY) return false;
+        String formatStr = getString(COMPLETION_SCHEDULE_DATE_FORMAT_CONFIG);
+        return !formatStr.contains("Y") && !formatStr.contains("y");
+    }
+
+    /**
+     * Returns {@code true} if the configured date format contains no year field ({@code Y} or {@code y})
+     * and the period is {@link CompletionPeriod#MONTHLY}.
+     *
+     * <p>When {@code true}, {@code YEAR} must be injected fresh at each parse call.
+     *
+     * @return {@code true} if a fresh calendar year default must be applied at parse time.
+     */
+    public boolean requiresYearDefault() {
+        if (completionPeriod() != CompletionPeriod.MONTHLY) return false;
+        String formatStr = getString(COMPLETION_SCHEDULE_DATE_FORMAT_CONFIG);
+        return !formatStr.contains("y") && !formatStr.contains("Y");
+    }
+
+    /**
+     * Returns the {@link CompletionPeriod} that controls the completion boundary.
+     *
+     * @return the completion period.
+     */
+    public CompletionPeriod completionPeriod() {
+        String periodStr = getString(COMPLETION_SCHEDULE_PERIOD_CONFIG);
+        try {
+            return CompletionPeriod.valueOf(periodStr.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new ConfigException(
+                COMPLETION_SCHEDULE_PERIOD_CONFIG,
+                periodStr,
+                "Invalid period. Accepted values: DAILY, WEEKLY, MONTHLY"
+            );
+        }
+    }
+
+    /**
+     * Returns the configured first day of the week, used to resolve partial week-based date formats.
+     *
+     * <p>Only relevant for the {@link CompletionPeriod#WEEKLY} period when no day field is present
+     * in the date format (e.g. {@code yyyy-'W'ww} or {@code ww}). Defaults to {@link DayOfWeek#MONDAY}.
+     *
+     * @return the configured {@link DayOfWeek}.
+     */
+    public DayOfWeek weekStartDay() {
+        String dayStr = getString(COMPLETION_SCHEDULE_WEEK_START_DAY_CONFIG);
+        try {
+            return DayOfWeek.valueOf(dayStr.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new ConfigException(
+                COMPLETION_SCHEDULE_WEEK_START_DAY_CONFIG,
+                dayStr,
+                "Invalid day. Accepted values: MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY"
+            );
+        }
+    }
+
+    /**
+     * Returns the {@link ConfigDef} for this configuration class.
+     *
+     * @return the config definition.
+     */
+    public static ConfigDef configDef() {
+        return new ConfigDef()
+            .define(
+                COMPLETION_SCHEDULE_TIME_CONFIG,
+                ConfigDef.Type.STRING,
+                COMPLETION_SCHEDULE_TIME_DEFAULT,
+                new TimeValidator(),
+                ConfigDef.Importance.HIGH,
+                COMPLETION_SCHEDULE_TIME_DOC
+            )
+            .define(
+                COMPLETION_SCHEDULE_DATE_PATTERN_CONFIG,
+                ConfigDef.Type.STRING,
+                COMPLETION_SCHEDULE_DATE_PATTERN_DEFAULT,
+                new RegexValidator(),
+                ConfigDef.Importance.HIGH,
+                COMPLETION_SCHEDULE_DATE_PATTERN_DOC
+            )
+            .define(
+                COMPLETION_SCHEDULE_DATE_FORMAT_CONFIG,
+                ConfigDef.Type.STRING,
+                COMPLETION_SCHEDULE_DATE_FORMAT_DEFAULT,
+                new DateFormatValidator(),
+                ConfigDef.Importance.HIGH,
+                COMPLETION_SCHEDULE_DATE_FORMAT_DOC
+            )
+            .define(
+                COMPLETION_SCHEDULE_PERIOD_CONFIG,
+                ConfigDef.Type.STRING,
+                COMPLETION_SCHEDULE_PERIOD_DEFAULT,
+                new PeriodValidator(),
+                ConfigDef.Importance.HIGH,
+                COMPLETION_SCHEDULE_PERIOD_DOC
+            )
+            .define(
+                COMPLETION_SCHEDULE_WEEK_START_DAY_CONFIG,
+                ConfigDef.Type.STRING,
+                COMPLETION_SCHEDULE_WEEK_START_DAY_DEFAULT,
+                new WeekStartDayValidator(),
+                ConfigDef.Importance.LOW,
+                COMPLETION_SCHEDULE_WEEK_START_DAY_DOC
+            );
+    }
+
+    static class TimeValidator implements ConfigDef.Validator {
+        @Override
+        public void ensureValid(final String name, final Object value) {
+            if (value == null) {
+                throw new ConfigException(name, null, "Time configuration is required");
+            }
+            try {
+                LocalTime.parse(value.toString(), DateTimeFormatter.ofPattern("HH:mm:ss"));
+            } catch (DateTimeParseException e) {
+                throw new ConfigException(
+                    name, value, "Invalid time format. Expected format: HH:mm:ss (e.g., '23:59:59')"
+                );
+            }
+        }
+    }
+
+    static class RegexValidator implements ConfigDef.Validator {
+        @Override
+        public void ensureValid(final String name, final Object value) {
+            if (value == null) return;
+            try {
+                Pattern.compile(value.toString());
+            } catch (PatternSyntaxException e) {
+                throw new ConfigException(name, value, "Invalid regex pattern: " + e.getMessage());
+            }
+        }
+    }
+
+    static class DateFormatValidator implements ConfigDef.Validator {
+        @Override
+        public void ensureValid(final String name, final Object value) {
+            if (value == null) return;
+            try {
+                DateTimeFormatter.ofPattern(value.toString());
+            } catch (IllegalArgumentException e) {
+                throw new ConfigException(
+                    name, value,
+                    "Invalid date format pattern. Use a valid DateTimeFormatter pattern (e.g., 'yyyy-MM-dd')"
+                );
+            }
+        }
+    }
+
+    static class PeriodValidator implements ConfigDef.Validator {
+        @Override
+        public void ensureValid(final String name, final Object value) {
+            if (value == null) return;
+            try {
+                CompletionPeriod.valueOf(value.toString().toUpperCase());
+            } catch (IllegalArgumentException e) {
+                throw new ConfigException(
+                    name, value, "Invalid period. Accepted values: DAILY, WEEKLY, MONTHLY"
+                );
+            }
+        }
+    }
+
+    static class WeekStartDayValidator implements ConfigDef.Validator {
+        @Override
+        public void ensureValid(final String name, final Object value) {
+            if (value == null) return;
+            try {
+                DayOfWeek.valueOf(value.toString().toUpperCase());
+            } catch (IllegalArgumentException e) {
+                throw new ConfigException(
+                    name, value,
+                    "Invalid day. Accepted values: MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY"
+                );
+            }
+        }
+    }
+}

--- a/connect-file-pulse-plugin/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/CompletionPeriod.java
+++ b/connect-file-pulse-plugin/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/CompletionPeriod.java
@@ -1,0 +1,83 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) StreamThoughts
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.kafka.connect.filepulse.source;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+
+/**
+ * Defines the period unit used by {@link ScheduledCompletionStrategy} to determine
+ * when a file should be marked as COMPLETED relative to the date extracted from its filename.
+ *
+ * <p>The date format configured via
+ * {@link io.streamthoughts.kafka.connect.filepulse.config.ScheduledCompletionStrategyConfig#dateFormatter()}
+ * may be partial or full depending on the period:
+ * <ul>
+ *   <li>{@link #DAILY}   – expects a full date (e.g. {@code yyyy-MM-dd})</li>
+ *   <li>{@link #WEEKLY}  – supports week-based formats (e.g. {@code YYYY-'W'ww}) or full date formats
+ *       (e.g. {@code yyyy-MM-dd})</li>
+ *   <li>{@link #MONTHLY} – supports year-month formats (e.g. {@code yyyy-MM}) or full date formats
+ *       (e.g. {@code yyyy-MM-dd})</li>
+ * </ul>
+ */
+public enum CompletionPeriod {
+
+    /**
+     * Complete on the day immediately following the file's date.
+     */
+    DAILY {
+        @Override
+        public LocalDate nextCompletionDate(final LocalDate fileDate, final DayOfWeek weekStartDay) {
+            return fileDate.plusDays(1);
+        }
+    },
+
+    /**
+     * Complete on the first day of the next week (as defined by {@code weekStartDay}) following
+     * the week that contains the file's date.
+     */
+    WEEKLY {
+        @Override
+        public LocalDate nextCompletionDate(final LocalDate fileDate, final DayOfWeek weekStartDay) {
+            LocalDate thisWeekStart = fileDate.with(TemporalAdjusters.previousOrSame(weekStartDay));
+            return thisWeekStart.plusWeeks(1);
+        }
+    },
+
+    /**
+     * Complete on the first day of the month immediately following the file's date's month.
+     */
+    MONTHLY {
+        @Override
+        public LocalDate nextCompletionDate(final LocalDate fileDate, final DayOfWeek weekStartDay) {
+            return fileDate.with(TemporalAdjusters.firstDayOfNextMonth());
+        }
+    };
+
+    /**
+     * Calculates the date on which the file should be marked as completed,
+     * based on the date extracted from the filename.
+     *
+     * @param fileDate     the date extracted from the filename.
+     * @param weekStartDay the first day of the week, used by {@link #WEEKLY} to compute the next
+     *                     week boundary. Ignored by {@link #DAILY} and {@link #MONTHLY}.
+     * @return the date on which the file should be completed (at the configured scheduled time).
+     */
+    public abstract LocalDate nextCompletionDate(LocalDate fileDate, DayOfWeek weekStartDay);
+
+    /**
+     * Convenience overload using {@link DayOfWeek#MONDAY} as the week start day.
+     * Suitable for {@link #DAILY} and {@link #MONTHLY} where the week start day is irrelevant.
+     *
+     * @param fileDate the date extracted from the filename.
+     * @return the date on which the file should be completed.
+     */
+    public LocalDate nextCompletionDate(final LocalDate fileDate) {
+        return nextCompletionDate(fileDate, DayOfWeek.MONDAY);
+    }
+}

--- a/connect-file-pulse-plugin/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/DailyCompletionStrategy.java
+++ b/connect-file-pulse-plugin/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/DailyCompletionStrategy.java
@@ -7,180 +7,86 @@
 package io.streamthoughts.kafka.connect.filepulse.source;
 
 import io.streamthoughts.kafka.connect.filepulse.config.DailyCompletionStrategyConfig;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
+import io.streamthoughts.kafka.connect.filepulse.config.ScheduledCompletionStrategyConfig;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A {@link FileCompletionStrategy} that marks files as COMPLETED
- * at a scheduled time by extracting the date from the filename.
+ * A {@link FileCompletionStrategy} that marks files as COMPLETED the <strong>day after</strong>
+ * the date extracted from the filename, at a configurable time of day.
  *
- * <p>This is useful for "daily" files that are continuously appended throughout the day
- * and should only be marked as complete the <strong>next day</strong> at a specific time.
+ * <p><strong>Deprecated.</strong> Use {@link ScheduledCompletionStrategy} with
+ * {@code completion.schedule.period=DAILY} instead. This class is kept for backward compatibility
+ * and simply delegates to {@link ScheduledCompletionStrategy} after translating the legacy
+ * {@code daily.completion.schedule.*} config keys to the new {@code completion.schedule.*} keys.
  *
- * <p>The strategy extracts the date from the filename using a regex pattern. The file is completed
- * on the <strong>day after</strong> the date in the filename at the configured completion time.
- * Uses the system default timezone.
- *
- * <h3>Example</h3>
+ * <h3>Legacy configuration keys (still supported)</h3>
  * <ul>
- *   <li>File: <code>logs-2025-12-08.log</code></li>
- *   <li>Completion time: <code>01:00:00</code></li>
- *   <li>File created: December 8, 2025 at 6:00 AM</li>
- *   <li><strong>File will be completed: December 9, 2025 at 01:00:00</strong></li>
+ *   <li>{@code daily.completion.schedule.time}         → {@code completion.schedule.time}</li>
+ *   <li>{@code daily.completion.schedule.date.pattern} → {@code completion.schedule.date.pattern}</li>
+ *   <li>{@code daily.completion.schedule.date.format}  → {@code completion.schedule.date.format}</li>
  * </ul>
  *
- * <p>This ensures that all data written during the day (December 8) is collected,
- * with a 1-hour buffer into the next day before the file is marked complete.
- *
- * <h3>Configuration</h3>
- * <ul>
- *   <li><code>completion.schedule.time</code>: Time to complete files (HH:mm:ss format, e.g., "01:00:00")</li>
- *   <li><code>completion.schedule.date.pattern</code>:
- *      Regex pattern to extract date from filename (default: ".*?(\\d{4}-\\d{2}-\\d{2}).*")</li>
- *   <li><code>completion.schedule.date.format</code>: Date format in the filename (default: "yyyy-MM-dd")</li>
- * </ul>
- *
- * <h3>Example filename patterns</h3>
- * <ul>
- *   <li><code>logs-2025-12-08.log</code> → pattern: ".*?(\\d{4}-\\d{2}-\\d{2}).*", format: "yyyy-MM-dd"</li>
- *   <li><code>app-20251208.log</code> → pattern: ".*?(\\d{8}).*", format: "yyyyMMdd"</li>
- * </ul>
+ * @deprecated Use {@link ScheduledCompletionStrategy} with {@code completion.schedule.period=DAILY}.
  */
-public class DailyCompletionStrategy implements FileCompletionStrategy, LongLivedFileReadStrategy {
+@Deprecated
+public class DailyCompletionStrategy extends ScheduledCompletionStrategy {
 
     private static final Logger LOG = LoggerFactory.getLogger(DailyCompletionStrategy.class);
 
-    private LocalTime scheduledCompletionTime;
-    private Pattern datePattern;
-    private DateTimeFormatter dateFormatter;
-
     /**
      * {@inheritDoc}
+     *
+     * <p>Translates the legacy {@code daily.completion.schedule.*} config keys to the new
+     * {@code completion.schedule.*} keys
      */
     @Override
     public void configure(final Map<String, ?> configs) {
-        DailyCompletionStrategyConfig config = new DailyCompletionStrategyConfig(configs);
-        this.scheduledCompletionTime = config.scheduledCompletionTime();
-        this.datePattern = config.datePattern();
-        this.dateFormatter = config.dateFormatter();
-
-        LOG.info(
-            "Configured DailyCompletionStrategy: completionTime={}, datePattern={}, dateFormat={}, timezone={}",
-            scheduledCompletionTime, datePattern.pattern(), dateFormatter, ZoneId.systemDefault()
+        LOG.warn(
+            "DailyCompletionStrategy is deprecated. " +
+                "Please migrate to ScheduledCompletionStrategy with completion.schedule.period=DAILY."
         );
+
+        Map<String, Object> translated = new HashMap<>(configs.size() + 1);
+
+        // Copy all existing keys first (allows completion.schedule.* keys to be passed directly
+        // if someone is already partially migrated)
+        configs.forEach((k, v) -> translated.put(k.toString(), v));
+
+        // Remap legacy daily.* keys → completion.schedule.* keys (only if the new key is not already set)
+        remapIfAbsent(configs, translated,
+            DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_TIME_CONFIG,
+            ScheduledCompletionStrategyConfig.COMPLETION_SCHEDULE_TIME_CONFIG);
+
+        remapIfAbsent(configs, translated,
+            DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_DATE_PATTERN_CONFIG,
+            ScheduledCompletionStrategyConfig.COMPLETION_SCHEDULE_DATE_PATTERN_CONFIG);
+
+        remapIfAbsent(configs, translated,
+            DailyCompletionStrategyConfig.COMPLETION_SCHEDULE_DATE_FORMAT_CONFIG,
+            ScheduledCompletionStrategyConfig.COMPLETION_SCHEDULE_DATE_FORMAT_CONFIG);
+
+        // Always force DAILY period regardless of what caller may have set
+        translated.put(ScheduledCompletionStrategyConfig.COMPLETION_SCHEDULE_PERIOD_CONFIG,
+            CompletionPeriod.DAILY.name());
+
+        super.configure(translated);
     }
 
     /**
-     * {@inheritDoc}
+     * Copies the value from {@code legacyKey} in {@code source} into {@code target} under
+     * {@code newKey}, but only when {@code newKey} is not already present in {@code target}.
      */
-    @Override
-    public boolean shouldComplete(final FileObjectContext context) {
-        // Extract date from filename
-        LocalDate fileDate;
-        try {
-            fileDate = extractDateFromFilename(context.metadata().stringURI());
-        } catch (Exception e) {
-            LOG.warn(
-                "Could not extract date from filename '{}': {}. " +
-                    "File will not be completed until date can be determined.",
-                context.metadata().stringURI(),
-                e.getMessage()
-            );
-            // If we can't extract the date, don't complete the file
-            return false;
+    private static void remapIfAbsent(
+        final Map<String, ?> source,
+        final Map<String, Object> target,
+        final String legacyKey,
+        final String newKey
+    ) {
+        if (!target.containsKey(newKey) && source.containsKey(legacyKey)) {
+            target.put(newKey, source.get(legacyKey));
         }
-
-        // Calculate when this file should be completed
-        Instant fileCompletionTime = calculateCompletionTimeForDate(fileDate);
-        Instant now = Instant.now();
-
-        boolean timeReached = now.isAfter(fileCompletionTime) || now.equals(fileCompletionTime);
-
-        if (timeReached) {
-            LOG.info(
-                "Scheduled completion time reached for file '{}' (date: {}, completion time: {}, now: {})",
-                context.metadata().stringURI(),
-                fileDate,
-                fileCompletionTime,
-                now
-            );
-        }
-
-        return timeReached;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public boolean shouldAttemptRead(final FileObjectMeta objectMeta, final FileObjectOffset offset) {
-        // Always attempt to read if the file should be completed
-        boolean shouldRead = shouldComplete(new FileObjectContext(objectMeta))
-            || LongLivedFileReadStrategy.super.shouldAttemptRead(objectMeta, offset);
-
-        if (!shouldRead) {
-            LOG.debug("Deferring read for file '{}' until file is updated or scheduled completion time is reached.",
-                objectMeta.stringURI());
-        }
-
-        return shouldRead;
-    }
-
-    /**
-     * Extract the date from the filename using the configured pattern and format.
-     *
-     * @param filename the filename or URI
-     * @return the parsed date
-     * @throws IllegalArgumentException if the date cannot be extracted or parsed
-     */
-    private LocalDate extractDateFromFilename(String filename) {
-        Matcher matcher = datePattern.matcher(filename);
-        if (!matcher.matches()) {
-            throw new IllegalArgumentException(
-                "Filename does not match date pattern: " + filename
-            );
-        }
-
-        // Extract the date string from the first capturing group
-        String dateStr = matcher.group(1);
-
-        try {
-            return LocalDate.parse(dateStr, dateFormatter);
-        } catch (DateTimeParseException e) {
-            throw new IllegalArgumentException(
-                "Could not parse date '" + dateStr + "' from filename '" +
-                    filename + "' using format: " + dateFormatter,
-                e
-            );
-        }
-    }
-
-    /**
-     * Calculate the completion time for a given file date using the system default timezone.
-     * The completion time is the configured time on the <strong>day after</strong> the file's date.
-     *
-     * <p>For example, if the file is for 2025-12-08 and completion time is 01:00:00,
-     * the file should be completed at <strong>2025-12-09 01:00:00</strong> (in the system timezone).
-     *
-     * <p>This ensures that all data written during the file's day (Dec 8) is collected,
-     * with a buffer period into the next day before marking the file as complete.
-     *
-     * @param fileDate the date extracted from the filename
-     * @return the instant when the file should be completed
-     */
-    private Instant calculateCompletionTimeForDate(LocalDate fileDate) {
-        LocalDate completionDate = fileDate.plusDays(1);
-        LocalDateTime completionDateTime = LocalDateTime.of(completionDate, scheduledCompletionTime);
-        return completionDateTime.atZone(ZoneId.systemDefault()).toInstant();
     }
 }

--- a/connect-file-pulse-plugin/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/ScheduledCompletionStrategy.java
+++ b/connect-file-pulse-plugin/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/ScheduledCompletionStrategy.java
@@ -1,0 +1,237 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) StreamThoughts
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.kafka.connect.filepulse.source;
+
+import io.streamthoughts.kafka.connect.filepulse.config.ScheduledCompletionStrategyConfig;
+import java.time.DayOfWeek;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+import java.time.temporal.IsoFields;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A generic {@link FileCompletionStrategy} that marks long-lived files as COMPLETED
+ * at a configurable scheduled time relative to the date extracted from the filename.
+ *
+ * <p>This is useful for files that are continuously appended over a period (day, week, month)
+ * and should only be marked as complete once that period has ended, plus a configurable time buffer.
+ * The strategy also implements {@link LongLivedFileReadStrategy} to avoid unnecessary polling
+ * when no new data is expected.
+ *
+ * <h3>How completion is calculated</h3>
+ * <ol>
+ *   <li>The date is extracted from the filename using the configured regex pattern.</li>
+ *   <li>The next period boundary is computed from that date according to
+ *       the configured {@link CompletionPeriod}.</li>
+ *   <li>The file is marked COMPLETED when the current time is at or after
+ *       {@code <nextPeriodBoundary> + <scheduledTime>} in the system default timezone.</li>
+ * </ol>
+ *
+ * <h3>Examples</h3>
+ * <table border="1">
+ *   <tr><th>Period</th><th>File date</th><th>Scheduled time</th><th>Completes at</th></tr>
+ *   <tr><td>DAILY</td>  <td>2026-03-10</td><td>01:00:00</td><td>2026-03-11 01:00:00</td></tr>
+ *   <tr><td>WEEKLY</td> <td>2026-03-10 (Tue)</td><td>01:00:00</td><td>2026-03-16 (Mon) 01:00:00</td></tr>
+ *   <tr><td>MONTHLY</td><td>2026-03-10</td><td>01:00:00</td><td>2026-04-01 01:00:00</td></tr>
+ * </table>
+ *
+ * <h3>Configuration</h3>
+ * <ul>
+ *   <li>{@code completion.schedule.time}         – Time-of-day (HH:mm:ss) at which to complete
+ *       (default: {@code 00:01:00}).</li>
+ *   <li>{@code completion.schedule.date.pattern} – Regex with one capturing group for the date in the filename
+ *       (default: {@code .*?(\d{4}-\d{2}-\d{2}).*}).</li>
+ *   <li>{@code completion.schedule.date.format}  – DateTimeFormatter pattern for the captured date
+ *       (default: {@code yyyy-MM-dd}).</li>
+ *   <li>{@code completion.schedule.period}       – {@link CompletionPeriod}: {@code DAILY} (default),
+ *       {@code WEEKLY}, or {@code MONTHLY}.</li>
+ * </ul>
+ */
+public class ScheduledCompletionStrategy implements FileCompletionStrategy, LongLivedFileReadStrategy {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ScheduledCompletionStrategy.class);
+
+    private LocalTime scheduledCompletionTime;
+    private Pattern datePattern;
+    private DateTimeFormatter dateFormatter;
+    private CompletionPeriod completionPeriod;
+    private DayOfWeek weekStartDay;
+    private boolean requiresWeekBasedYearDefault;
+    private boolean requiresYearDefault;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void configure(final Map<String, ?> configs) {
+        ScheduledCompletionStrategyConfig config = new ScheduledCompletionStrategyConfig(configs);
+        this.scheduledCompletionTime = config.scheduledCompletionTime();
+        this.datePattern = config.datePattern();
+        this.dateFormatter = config.dateFormatter();
+        this.completionPeriod = config.completionPeriod();
+        this.weekStartDay = config.weekStartDay();
+        this.requiresWeekBasedYearDefault = config.requiresWeekBasedYearDefault();
+        this.requiresYearDefault = config.requiresYearDefault();
+
+        LOG.info(
+            "Configured ScheduledCompletionStrategy: period={}, completionTime={}, " +
+                "datePattern={}, dateFormat={}, timezone={}",
+            completionPeriod,
+            scheduledCompletionTime,
+            datePattern.pattern(),
+            dateFormatter,
+            ZoneId.systemDefault()
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Returns {@code true} when the current instant is at or after the completion instant
+     * computed from the date in the filename and the configured period and time.
+     */
+    @Override
+    public boolean shouldComplete(final FileObjectContext context) {
+        LocalDate fileDate;
+        try {
+            fileDate = extractDateFromFilename(context.metadata().stringURI());
+        } catch (Exception e) {
+            LOG.warn(
+                "Could not extract date from filename '{}': {}. " +
+                    "File will not be completed until date can be determined.",
+                context.metadata().stringURI(),
+                e.getMessage()
+            );
+            return false;
+        }
+
+        Instant fileCompletionInstant = calculateCompletionInstant(fileDate);
+        Instant now = Instant.now();
+        boolean shouldComplete = !now.isBefore(fileCompletionInstant) || fileDate.isAfter(LocalDate.now());
+
+        if (shouldComplete) {
+            LOG.info(
+                "Scheduled completion time reached for file '{}' " +
+                    "(period={}, fileDate={}, completionInstant={}, now={})",
+                context.metadata().stringURI(),
+                completionPeriod,
+                fileDate,
+                fileCompletionInstant,
+                now
+            );
+        }
+
+        return shouldComplete;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Attempts a read either when the scheduled completion time has been reached
+     * (so the file can be flushed) or when the file has been modified since the last
+     * known offset (default {@link LongLivedFileReadStrategy} behaviour).
+     */
+    @Override
+    public boolean shouldAttemptRead(final FileObjectMeta objectMeta, final FileObjectOffset offset) {
+        boolean shouldRead = shouldComplete(new FileObjectContext(objectMeta))
+            || LongLivedFileReadStrategy.super.shouldAttemptRead(objectMeta, offset);
+
+        if (!shouldRead) {
+            LOG.debug(
+                "Deferring read for file '{}' until file is updated or scheduled completion time is reached.",
+                objectMeta.stringURI()
+            );
+        }
+
+        return shouldRead;
+    }
+
+    /**
+     * Extracts and parses the date from the given filename (or URI string).
+     *
+     * <p>The date string is captured from the filename using the configured regex pattern.
+     * For formats that include a year field, the base {@link DateTimeFormatter} built at configure time
+     * is used directly. For partial formats without a year field, a fresh formatter is built at each
+     * call by prepending a {@code parseDefaulting} for the current year (via {@link LocalDate#now()}),
+     * ensuring correctness across year boundaries without a connector restart:
+     *
+     * @param filename the filename or URI string.
+     * @return the parsed {@link LocalDate}.
+     * @throws IllegalArgumentException if the filename does not match the pattern or the date cannot be parsed.
+     */
+    private LocalDate extractDateFromFilename(final String filename) {
+        Matcher matcher = datePattern.matcher(filename);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException(
+                "Filename does not match date pattern '" + datePattern.pattern() + "': " + filename
+            );
+        }
+
+        String dateStr = matcher.group(1);
+
+        try {
+            DateTimeFormatter formatter = resolveFormatter();
+            return LocalDate.from(formatter.parse(dateStr));
+        } catch (Exception e) {
+            throw new IllegalArgumentException(
+                "Could not parse date '" + dateStr + "' from filename '" +
+                    filename + "' using format '" + dateFormatter + "'",
+                e
+            );
+        }
+    }
+
+    /**
+     * Returns the formatter to use for parsing the date string captured from the filename.
+     *
+     * <p>When a year default is required (week-only or month-only format), a fresh formatter is built
+     * at each call using {@link LocalDate#now()} so the year is always current
+     *
+     * @return the formatter to use.
+     */
+    private DateTimeFormatter resolveFormatter() {
+        if (requiresWeekBasedYearDefault) {
+            return new DateTimeFormatterBuilder()
+                .parseDefaulting(IsoFields.WEEK_BASED_YEAR, LocalDate.now().get(IsoFields.WEEK_BASED_YEAR))
+                .parseDefaulting(ChronoField.DAY_OF_WEEK, weekStartDay.getValue())
+                .appendValue(IsoFields.WEEK_OF_WEEK_BASED_YEAR)
+                .toFormatter();
+        }
+        if (requiresYearDefault) {
+            return new DateTimeFormatterBuilder()
+                .parseDefaulting(ChronoField.YEAR, LocalDate.now().getYear())
+                .append(dateFormatter)
+                .toFormatter();
+        }
+        return dateFormatter;
+    }
+
+    /**
+     * Calculates the {@link Instant} at which the file should be completed.
+     *
+     * <p>The completion instant is:
+     * {@code nextPeriodBoundary(fileDate) @ scheduledCompletionTime} in the system default timezone.
+     *
+     * @param fileDate the date extracted from the filename.
+     * @return the instant when the file should be completed.
+     */
+    private Instant calculateCompletionInstant(final LocalDate fileDate) {
+        LocalDate completionDate = completionPeriod.nextCompletionDate(fileDate, weekStartDay);
+        LocalDateTime completionDateTime = LocalDateTime.of(completionDate, scheduledCompletionTime);
+        return completionDateTime.atZone(ZoneId.systemDefault()).toInstant();
+    }
+}

--- a/connect-file-pulse-plugin/src/test/java/io/streamthoughts/kafka/connect/filepulse/config/ScheduledCompletionStrategyConfigTest.java
+++ b/connect-file-pulse-plugin/src/test/java/io/streamthoughts/kafka/connect/filepulse/config/ScheduledCompletionStrategyConfigTest.java
@@ -1,0 +1,160 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) StreamThoughts
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.kafka.connect.filepulse.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import io.streamthoughts.kafka.connect.filepulse.source.CompletionPeriod;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+import org.apache.kafka.common.config.ConfigException;
+import org.junit.Test;
+
+/**
+ * Test class for {@link ScheduledCompletionStrategyConfig}.
+ */
+public class ScheduledCompletionStrategyConfigTest {
+
+    // -------------------------------------------------------------------------
+    // Defaults
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testDefaultConfiguration() {
+        ScheduledCompletionStrategyConfig config = new ScheduledCompletionStrategyConfig(Map.of());
+
+        assertEquals(LocalTime.of(0, 1, 0), config.scheduledCompletionTime());
+        assertNotNull(config.datePattern());
+        assertNotNull(config.dateFormatter());
+        assertEquals(CompletionPeriod.DAILY, config.completionPeriod());
+    }
+
+    // -------------------------------------------------------------------------
+    // Period
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testPeriodDaily() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ScheduledCompletionStrategyConfig.COMPLETION_SCHEDULE_PERIOD_CONFIG, "DAILY");
+
+        ScheduledCompletionStrategyConfig config = new ScheduledCompletionStrategyConfig(props);
+        assertEquals(CompletionPeriod.DAILY, config.completionPeriod());
+    }
+
+    @Test
+    public void testPeriodWeekly() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ScheduledCompletionStrategyConfig.COMPLETION_SCHEDULE_PERIOD_CONFIG, "WEEKLY");
+
+        ScheduledCompletionStrategyConfig config = new ScheduledCompletionStrategyConfig(props);
+        assertEquals(CompletionPeriod.WEEKLY, config.completionPeriod());
+    }
+
+    @Test
+    public void testPeriodMonthly() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ScheduledCompletionStrategyConfig.COMPLETION_SCHEDULE_PERIOD_CONFIG, "MONTHLY");
+
+        ScheduledCompletionStrategyConfig config = new ScheduledCompletionStrategyConfig(props);
+        assertEquals(CompletionPeriod.MONTHLY, config.completionPeriod());
+    }
+
+    @Test(expected = ConfigException.class)
+    public void testInvalidPeriod() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ScheduledCompletionStrategyConfig.COMPLETION_SCHEDULE_PERIOD_CONFIG, "HOURLY");
+
+        new ScheduledCompletionStrategyConfig(props).completionPeriod();
+    }
+
+    // -------------------------------------------------------------------------
+    // Time
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testValidTime() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ScheduledCompletionStrategyConfig.COMPLETION_SCHEDULE_TIME_CONFIG, "06:30:15");
+
+        ScheduledCompletionStrategyConfig config = new ScheduledCompletionStrategyConfig(props);
+        assertEquals(LocalTime.of(6, 30, 15), config.scheduledCompletionTime());
+    }
+
+    @Test(expected = ConfigException.class)
+    public void testInvalidTime_NoSeconds() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ScheduledCompletionStrategyConfig.COMPLETION_SCHEDULE_TIME_CONFIG, "01:00");
+
+        new ScheduledCompletionStrategyConfig(props).scheduledCompletionTime();
+    }
+
+    @Test(expected = ConfigException.class)
+    public void testInvalidTime_InvalidHour() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ScheduledCompletionStrategyConfig.COMPLETION_SCHEDULE_TIME_CONFIG, "25:00:00");
+
+        new ScheduledCompletionStrategyConfig(props).scheduledCompletionTime();
+    }
+
+    @Test(expected = ConfigException.class)
+    public void testInvalidTime_InvalidString() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ScheduledCompletionStrategyConfig.COMPLETION_SCHEDULE_TIME_CONFIG, "not-a-time");
+
+        new ScheduledCompletionStrategyConfig(props).scheduledCompletionTime();
+    }
+
+    // -------------------------------------------------------------------------
+    // Date pattern
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testValidPattern() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ScheduledCompletionStrategyConfig.COMPLETION_SCHEDULE_DATE_PATTERN_CONFIG, ".*?(\\d{8}).*");
+
+        ScheduledCompletionStrategyConfig config = new ScheduledCompletionStrategyConfig(props);
+        Pattern pattern = config.datePattern();
+        assertNotNull(pattern);
+        assertEquals(".*?(\\d{8}).*", pattern.pattern());
+    }
+
+    @Test(expected = ConfigException.class)
+    public void testInvalidPattern() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ScheduledCompletionStrategyConfig.COMPLETION_SCHEDULE_DATE_PATTERN_CONFIG, "[invalid(regex");
+
+        new ScheduledCompletionStrategyConfig(props).datePattern();
+    }
+
+    // -------------------------------------------------------------------------
+    // Date format
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testValidDateFormat() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ScheduledCompletionStrategyConfig.COMPLETION_SCHEDULE_DATE_FORMAT_CONFIG, "yyyyMMdd");
+
+        ScheduledCompletionStrategyConfig config = new ScheduledCompletionStrategyConfig(props);
+        DateTimeFormatter formatter = config.dateFormatter();
+        assertNotNull(formatter);
+    }
+
+    @Test(expected = ConfigException.class)
+    public void testInvalidDateFormat() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ScheduledCompletionStrategyConfig.COMPLETION_SCHEDULE_DATE_FORMAT_CONFIG, "invalid-format-xxx");
+
+        new ScheduledCompletionStrategyConfig(props).dateFormatter();
+    }
+}

--- a/connect-file-pulse-plugin/src/test/java/io/streamthoughts/kafka/connect/filepulse/source/CompletionPeriodTest.java
+++ b/connect-file-pulse-plugin/src/test/java/io/streamthoughts/kafka/connect/filepulse/source/CompletionPeriodTest.java
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) StreamThoughts
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.kafka.connect.filepulse.source;
+
+import static org.junit.Assert.assertEquals;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import org.junit.Test;
+
+/**
+ * Test class for {@link CompletionPeriod}.
+ */
+public class CompletionPeriodTest {
+
+    @Test
+    public void daily_nextCompletionDate_shouldReturnNextDay() {
+        LocalDate date = LocalDate.of(2026, 3, 10);
+        assertEquals(LocalDate.of(2026, 3, 11), CompletionPeriod.DAILY.nextCompletionDate(date));
+    }
+
+    @Test
+    public void weekly_nextCompletionDate_fromTuesday_withMondayStart_shouldReturnFollowingMonday() {
+        // Tuesday 2026-03-10 → next week's Monday = 2026-03-16
+        LocalDate tuesday = LocalDate.of(2026, 3, 10);
+        assertEquals(LocalDate.of(2026, 3, 16),
+            CompletionPeriod.WEEKLY.nextCompletionDate(tuesday, DayOfWeek.MONDAY));
+    }
+
+    @Test
+    public void weekly_nextCompletionDate_fromMonday_withMondayStart_shouldReturnFollowingMonday() {
+        // Monday 2026-03-09 → next week's Monday = 2026-03-16
+        LocalDate monday = LocalDate.of(2026, 3, 9);
+        assertEquals(LocalDate.of(2026, 3, 16),
+            CompletionPeriod.WEEKLY.nextCompletionDate(monday, DayOfWeek.MONDAY));
+    }
+
+    @Test
+    public void weekly_nextCompletionDate_fromTuesday_withSundayStart_shouldReturnFollowingSunday() {
+        // Tuesday 2026-03-10, SUNDAY week start: this week's Sunday was 2026-03-08 → next = 2026-03-15
+        LocalDate tuesday = LocalDate.of(2026, 3, 10);
+        assertEquals(LocalDate.of(2026, 3, 15),
+            CompletionPeriod.WEEKLY.nextCompletionDate(tuesday, DayOfWeek.SUNDAY));
+    }
+
+    @Test
+    public void monthly_nextCompletionDate_shouldReturnFirstDayOfNextMonth() {
+        LocalDate date = LocalDate.of(2026, 3, 10);
+        assertEquals(LocalDate.of(2026, 4, 1), CompletionPeriod.MONTHLY.nextCompletionDate(date));
+    }
+
+    @Test
+    public void monthly_nextCompletionDate_fromLastDayOfMonth_shouldReturnFirstDayOfNextMonth() {
+        LocalDate lastDay = LocalDate.of(2026, 3, 31);
+        assertEquals(LocalDate.of(2026, 4, 1), CompletionPeriod.MONTHLY.nextCompletionDate(lastDay));
+    }
+}

--- a/connect-file-pulse-plugin/src/test/java/io/streamthoughts/kafka/connect/filepulse/source/DailyCompletionStrategyTest.java
+++ b/connect-file-pulse-plugin/src/test/java/io/streamthoughts/kafka/connect/filepulse/source/DailyCompletionStrategyTest.java
@@ -157,21 +157,6 @@ public class DailyCompletionStrategyTest {
                    strategy.shouldComplete(context));
     }
 
-    @Test
-    public void testShouldNotCompleteForFutureFile() {
-        Map<String, Object> config = createConfig("01:00:00", null, null);
-        strategy.configure(config);
-
-        // File from 5 days in the future
-        // (completion is 4 days in the future at 01:00:00)
-        LocalDate fiveDaysFromNow = LocalDate.now().plusDays(5);
-        String filename = String.format("logs-%s.log", fiveDaysFromNow.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
-        FileObjectContext context = createContext(filename);
-
-        assertFalse("Future file should not be marked as complete",
-                    strategy.shouldComplete(context));
-    }
-
 
     @Test
     public void testFileCompletesNextDayAtScheduledTime() {
@@ -243,9 +228,7 @@ public class DailyCompletionStrategyTest {
         Map<String, Object> config = createConfig("23:59:59", null, null);
         strategy.configure(config);
 
-        // File from 5 days in future - not complete yet and not modified
-        LocalDate fiveDaysFromNow = LocalDate.now().plusDays(5);
-        String filename = String.format("logs-%s.log", fiveDaysFromNow.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+        String filename = String.format("logs-%s.log", LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
 
         long fileModifiedTime = 1705330800000L; // 2024-01-15 11:00:00 UTC
         long offsetTime = 1705334400000L; // 2024-01-15 12:00:00 UTC (newer than file)

--- a/connect-file-pulse-plugin/src/test/java/io/streamthoughts/kafka/connect/filepulse/source/ScheduledCompletionStrategyTest.java
+++ b/connect-file-pulse-plugin/src/test/java/io/streamthoughts/kafka/connect/filepulse/source/ScheduledCompletionStrategyTest.java
@@ -1,0 +1,338 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) StreamThoughts
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.kafka.connect.filepulse.source;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URI;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAdjusters;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test class for {@link ScheduledCompletionStrategy}.
+ *
+ * <p>Covers all three {@link CompletionPeriod} values (DAILY, WEEKLY, MONTHLY) as well as
+ * the {@link LongLivedFileReadStrategy} behaviour inherited by the strategy.
+ */
+public class ScheduledCompletionStrategyTest {
+
+    private static final DateTimeFormatter MMM_FORMATTER = DateTimeFormatter.ofPattern("MMM");
+
+    private ScheduledCompletionStrategy strategy;
+
+    @Before
+    public void setUp() {
+        strategy = new ScheduledCompletionStrategy();
+    }
+
+    private Map<String, Object> config(String period, String time, String pattern, String format) {
+        Map<String, Object> config = new HashMap<>();
+        config.put("completion.schedule.period", period);
+        config.put("completion.schedule.time", time);
+        if (pattern != null) config.put("completion.schedule.date.pattern", pattern);
+        if (format  != null) config.put("completion.schedule.date.format",  format);
+        return config;
+    }
+
+    private FileObjectContext context(String filename) {
+        long ts = 1705334400000L; // 2024-01-15 12:00:00 UTC — fixed timestamp, irrelevant for date extraction
+        GenericFileObjectMeta meta = new GenericFileObjectMeta.Builder()
+            .withUri(URI.create("file:///data/" + filename))
+            .withName(filename)
+            .withContentLength(1000L)
+            .withLastModified(ts)
+            .build();
+        return new FileObjectContext(meta);
+    }
+
+    private String dailyFilename(LocalDate date) {
+        return "logs-" + date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")) + ".log";
+    }
+
+    // -------------------------------------------------------------------------
+    // DAILY
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void daily_shouldComplete_forOldFile() {
+        strategy.configure(config("DAILY", "01:00:00", null, null));
+
+        FileObjectContext ctx = context(dailyFilename(LocalDate.now().minusDays(10)));
+        assertTrue(strategy.shouldComplete(ctx));
+    }
+
+    @Test
+    public void daily_shouldNotComplete_forTodayFile() {
+        strategy.configure(config("DAILY", "01:00:00", null, null));
+
+        FileObjectContext ctx = context(dailyFilename(LocalDate.now()));
+        assertFalse(strategy.shouldComplete(ctx));
+    }
+
+
+    @Test
+    public void daily_shouldNotComplete_whenDateCannotBeExtracted() {
+        strategy.configure(config("DAILY", "01:00:00", null, null));
+
+        assertFalse(strategy.shouldComplete(context("no-date-here.log")));
+    }
+
+    @Test
+    public void daily_shouldComplete_withCompactDateFormat() {
+        strategy.configure(config("DAILY", "01:00:00", ".*?(\\d{8}).*", "yyyyMMdd"));
+
+        LocalDate tenDaysAgo = LocalDate.now().minusDays(10);
+        String filename = "app-" + tenDaysAgo.format(DateTimeFormatter.ofPattern("yyyyMMdd")) + ".log";
+        assertTrue(strategy.shouldComplete(context(filename)));
+    }
+
+    // -------------------------------------------------------------------------
+    // WEEKLY — full date format (yyyy-MM-dd)
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void weekly_shouldComplete_forFileFromTwoWeeksAgo() {
+        strategy.configure(config("WEEKLY", "00:01:00", null, null));
+
+        FileObjectContext ctx = context(dailyFilename(LocalDate.now().minusWeeks(2)));
+        assertTrue(strategy.shouldComplete(ctx));
+    }
+
+    @Test
+    public void weekly_shouldNotComplete_forCurrentWeekFile() {
+        strategy.configure(config("WEEKLY", "01:00:00", null, null));
+
+        // Use the Monday of the current week — always within the current week regardless of today's day
+        LocalDate thisMonday = LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        FileObjectContext ctx = context(dailyFilename(thisMonday));
+        assertFalse(strategy.shouldComplete(ctx));
+    }
+
+    // -------------------------------------------------------------------------
+    // WEEKLY — week number format (YYYY-'W'ww)
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void weekly_shouldComplete_forOldWeekNumberFile() {
+        // YYYY (week-based year) must be paired with ww (localized week-of-week-based-year).
+        // yyyy (calendar year) is incompatible with ww — they live in different resolver chains.
+        strategy.configure(config("WEEKLY", "06:00:00", ".*?(\\d{4}-W\\d{2}).*", "YYYY-'W'ww"));
+
+        FileObjectContext ctx = context("report-2024-W01.log");
+        assertTrue(strategy.shouldComplete(ctx));
+    }
+
+
+    // -------------------------------------------------------------------------
+    // WEEKLY — week-only format (ww), year defaulted to current week-based year
+    // Filename convention: report-W<n>.log (e.g. report-W13.log or report-W5.log)
+    // -------------------------------------------------------------------------
+
+    private static final String WEEK_ONLY_PATTERN = ".*-W(\\d{1,2})\\.log";
+    private static final String WEEK_ONLY_FORMAT  = "ww";
+
+    private String weekOnlyFilename(final int weekNumber) {
+        return String.format("report-W%d.log", weekNumber);
+    }
+
+    private int currentWeekNumber() {
+        return LocalDate.now().get(java.time.temporal.IsoFields.WEEK_OF_WEEK_BASED_YEAR);
+    }
+
+    @Test
+    public void weekly_weekOnlyFormat_shouldComplete_forOldWeek() {
+        strategy.configure(config("WEEKLY", "01:00:00", WEEK_ONLY_PATTERN, WEEK_ONLY_FORMAT));
+
+        int pastWeek = LocalDate.now().minusWeeks(4).get(java.time.temporal.IsoFields.WEEK_OF_WEEK_BASED_YEAR);
+        assertTrue(strategy.shouldComplete(context(weekOnlyFilename(pastWeek))));
+    }
+
+    @Test
+    public void weekly_weekOnlyFormat_shouldComplete_forSingleDigitWeek() {
+        // Tests that a 1-digit week number (e.g. report-W1.log) is parsed correctly
+        org.junit.Assume.assumeTrue("Requires current week > 2", currentWeekNumber() > 2);
+        strategy.configure(config("WEEKLY", "01:00:00", WEEK_ONLY_PATTERN, WEEK_ONLY_FORMAT));
+
+        assertTrue(strategy.shouldComplete(context(weekOnlyFilename(1))));
+    }
+
+    @Test
+    public void weekly_weekOnlyFormat_shouldNotComplete_forCurrentWeek() {
+        strategy.configure(config("WEEKLY", "01:00:00", WEEK_ONLY_PATTERN, WEEK_ONLY_FORMAT));
+
+        assertFalse(strategy.shouldComplete(context(weekOnlyFilename(currentWeekNumber()))));
+    }
+
+
+    // -------------------------------------------------------------------------
+    // WEEKLY — configurable week start day
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void weekly_sundayStart_shouldComplete_forOldWeek() {
+        Map<String, Object> cfg = config("WEEKLY", "01:00:00", null, null);
+        cfg.put("completion.schedule.week.start.day", "SUNDAY");
+        strategy.configure(cfg);
+
+        assertTrue(strategy.shouldComplete(context(dailyFilename(LocalDate.now().minusWeeks(4)))));
+    }
+
+    @Test
+    public void weekly_sundayStart_shouldNotComplete_forCurrentWeek() {
+        Map<String, Object> cfg = config("WEEKLY", "01:00:00", null, null);
+        cfg.put("completion.schedule.week.start.day", "SUNDAY");
+        strategy.configure(cfg);
+
+        // Use the Sunday of the current week (Sunday-based) — always within bounds regardless of today's day
+        LocalDate thisSunday = LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY));
+        assertFalse(strategy.shouldComplete(context(dailyFilename(thisSunday))));
+    }
+
+    // -------------------------------------------------------------------------
+    // MONTHLY — full date format (yyyy-MM-dd)
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void monthly_shouldComplete_forFileFromThreeMonthsAgo() {
+        strategy.configure(config("MONTHLY", "01:00:00", null, null));
+
+        FileObjectContext ctx = context(dailyFilename(LocalDate.now().minusMonths(3)));
+        assertTrue(strategy.shouldComplete(ctx));
+    }
+
+    @Test
+    public void monthly_shouldNotComplete_forFileFromThisMonth() {
+        strategy.configure(config("MONTHLY", "01:00:00", null, null));
+
+        FileObjectContext ctx = context(dailyFilename(LocalDate.now()));
+        assertFalse(strategy.shouldComplete(ctx));
+    }
+
+    // -------------------------------------------------------------------------
+    // MONTHLY — year-month format (yyyy-MM)
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void monthly_shouldComplete_forOldYearMonthFile() {
+        strategy.configure(config("MONTHLY", "02:00:00", ".*?(\\d{4}-\\d{2}).*", "yyyy-MM"));
+
+        LocalDate threeMonthsAgo = LocalDate.now().minusMonths(3);
+        String filename = String.format("export-%d-%02d.log",
+            threeMonthsAgo.getYear(), threeMonthsAgo.getMonthValue());
+        assertTrue(strategy.shouldComplete(context(filename)));
+    }
+
+    @Test
+    public void monthly_shouldNotComplete_forCurrentMonthYearMonthFile() {
+        strategy.configure(config("MONTHLY", "02:00:00", ".*?(\\d{4}-\\d{2}).*", "yyyy-MM"));
+
+        LocalDate now = LocalDate.now();
+        String filename = String.format("export-%d-%02d.log", now.getYear(), now.getMonthValue());
+        assertFalse(strategy.shouldComplete(context(filename)));
+    }
+
+    // -------------------------------------------------------------------------
+    // MONTHLY — month-only format (MM / MMM), year defaulted to current year
+    // Covers legacy filename conventions like report-01.csv or report-Jan.csv
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void monthly_monthOnlyFormat_numeric_shouldComplete_forPastMonth() {
+        strategy.configure(config("MONTHLY", "02:00:00", ".*?-(\\d{2})\\.csv", "MM"));
+
+        LocalDate twoMonthsAgo = LocalDate.now().minusMonths(2);
+        String filename = String.format("report-%02d.csv", twoMonthsAgo.getMonthValue());
+        assertTrue(strategy.shouldComplete(context(filename)));
+    }
+
+    @Test
+    public void monthly_monthOnlyFormat_numeric_shouldNotComplete_forCurrentMonth() {
+        strategy.configure(config("MONTHLY", "02:00:00", ".*?-(\\d{2})\\.csv", "MM"));
+
+        String filename = String.format("report-%02d.csv", LocalDate.now().getMonthValue());
+        assertFalse(strategy.shouldComplete(context(filename)));
+    }
+
+    @Test
+    public void monthly_monthOnlyFormat_text_shouldComplete_forPastMonth() {
+        strategy.configure(config("MONTHLY", "02:00:00", ".*?-([A-Za-z]{3})\\.csv", "MMM"));
+
+        LocalDate twoMonthsAgo = LocalDate.now().minusMonths(2);
+        String filename = "report-" + twoMonthsAgo.format(MMM_FORMATTER) + ".csv";
+        assertTrue(strategy.shouldComplete(context(filename)));
+    }
+
+    @Test
+    public void monthly_monthOnlyFormat_text_shouldNotComplete_forCurrentMonth() {
+        strategy.configure(config("MONTHLY", "02:00:00", ".*?-([A-Za-z]{3})\\.csv", "MMM"));
+
+        String filename = "report-" + LocalDate.now().format(MMM_FORMATTER) + ".csv";
+        assertFalse(strategy.shouldComplete(context(filename)));
+    }
+
+    // -------------------------------------------------------------------------
+    // LongLivedFileReadStrategy
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void shouldAttemptRead_whenFileIsComplete() {
+        strategy.configure(config("DAILY", "01:00:00", null, null));
+
+        long ts = 1705334400000L;
+        String filename = dailyFilename(LocalDate.now().minusDays(10));
+        GenericFileObjectMeta meta = new GenericFileObjectMeta.Builder()
+            .withUri(URI.create("file:///data/" + filename))
+            .withName(filename)
+            .withContentLength(1000L)
+            .withLastModified(ts)
+            .build();
+
+        assertTrue(strategy.shouldAttemptRead(meta, new FileObjectOffset(0, 0, ts)));
+    }
+
+    @Test
+    public void shouldAttemptRead_whenFileIsModifiedButNotComplete() {
+        strategy.configure(config("DAILY", "23:59:59", null, null));
+
+        long fileModified = 1705334400000L; // 12:00 UTC
+        long offsetTime   = 1705330800000L; // 11:00 UTC — older than file
+        String filename = dailyFilename(LocalDate.now().plusDays(5));
+        GenericFileObjectMeta meta = new GenericFileObjectMeta.Builder()
+            .withUri(URI.create("file:///data/" + filename))
+            .withName(filename)
+            .withContentLength(1000L)
+            .withLastModified(fileModified)
+            .build();
+
+        assertTrue(strategy.shouldAttemptRead(meta, new FileObjectOffset(0, 0, offsetTime)));
+    }
+
+    @Test
+    public void shouldNotAttemptRead_whenFileIsNotModifiedAndNotComplete() {
+        strategy.configure(config("DAILY", "23:59:59", null, null));
+
+        long fileModified = 1705330800000L; // 11:00 UTC
+        long offsetTime   = 1705334400000L; // 12:00 UTC — newer than file
+
+        String filename = dailyFilename(LocalDate.now());
+        GenericFileObjectMeta meta = new GenericFileObjectMeta.Builder()
+            .withUri(URI.create("file:///data/" + filename))
+            .withName(filename)
+            .withContentLength(1000L)
+            .withLastModified(fileModified)
+            .build();
+
+        assertFalse(strategy.shouldAttemptRead(meta, new FileObjectOffset(0, 0, offsetTime)));
+    }
+}

--- a/docs/content/en/docs/Developer Guide/file-completion-strategies.md
+++ b/docs/content/en/docs/Developer Guide/file-completion-strategies.md
@@ -1,5 +1,5 @@
 ---
-date: 2025-12-18
+date: 2026-03-23
 title: "File Completion Strategies"
 linkTitle: "File Completion Strategies"
 weight: 95
@@ -7,25 +7,26 @@ description: >
   Learn how to control when files are marked as COMPLETED using pluggable completion strategies for long-lived files.
 ---
 
-Connect File Pulse provides pluggable **File Completion Strategies** that control when files should be marked as COMPLETED. This feature is particularly useful for handling continuously appended files, such as daily log files or rolling data files.
+Connect File Pulse provides pluggable **File Completion Strategies** that control when files should be marked as COMPLETED. This feature is particularly useful for handling continuously appended files, such as daily log files, weekly reports, or monthly data exports.
 
 ## Overview
 
-Previously, files were **always** marked as COMPLETED immediately when they were fully read (EOF reached). While this works well for static files, it creates challenges for files that are continuously appended, such as:
+By default, files are marked as COMPLETED immediately when they are fully read (EOF reached). While this works well for static files, it creates challenges for files that are continuously appended, such as:
 
 - **Daily log files** that are active throughout the day
+- **Weekly report files** that accumulate data over a full week
+- **Monthly data exports** that are written incrementally over a month
 - **Rolling files** that continue to grow until a specific time
-- **Streaming data files** where you want to process data incrementally but only mark the file complete at specific times
 
 The File Completion Strategy feature provides a pluggable architecture that allows you to customize when files should be marked as COMPLETED.
 
 ## Configuration
 
-The completion strategy can be configured with the following connect property:
+The completion strategy is configured with the following connector property:
 
-| Configuration                      | Description                                                                                    | Type    | Default                                                                         | Importance |
-|------------------------------------|------------------------------------------------------------------------------------------------|---------|---------------------------------------------------------------------------------|------------|
-| `fs.completion.strategy.class`     | The fully qualified name of the class which determines when files should be marked as COMPLETED | class   | `io.streamthoughts.kafka.connect.filepulse.source.EofCompletionStrategy`      | high       |
+| Configuration                  | Description                                                                                     | Type  | Default                                                                     | Importance |
+|--------------------------------|-------------------------------------------------------------------------------------------------|-------|-----------------------------------------------------------------------------|------------|
+| `fs.completion.strategy.class` | Fully qualified class name of the strategy that determines when files are marked as COMPLETED. | class | `io.streamthoughts.kafka.connect.filepulse.source.EofCompletionStrategy`   | high       |
 
 ## Available Strategies
 
@@ -33,9 +34,7 @@ The completion strategy can be configured with the following connect property:
 
 **Behavior**: Marks files as COMPLETED immediately when they are fully read (End-of-File reached).
 
-**Use Case**: Static files that don't change once created or where you want the traditional immediate completion behavior.
-
-**Configuration**: This is the default behavior. You can explicitly configure it or simply omit the configuration.
+**Use Case**: Static files that don't change once created, or when you want the traditional immediate-completion behavior.
 
 ```json
 {
@@ -50,38 +49,143 @@ The completion strategy can be configured with the following connect property:
 
 ---
 
-### 2. DailyCompletionStrategy
+### 2. ScheduledCompletionStrategy
 
-**Purpose**: Mark files as COMPLETED at a scheduled time on the day **after** the file date by extracting the date from the filename.
+**Behavior**: Marks files as COMPLETED at a scheduled time relative to the date extracted from the filename.
+The strategy supports three period granularities controlled by the `completion.schedule.period` option:
 
-**Use Case**: Daily log files that are continuously appended throughout the day and should only be marked as complete the next day at a specific time (e.g., 1 AM the next day).
+| Period    | Completes at                                              | Example (file date `2026-03-10`, time `01:00:00`)  |
+|-----------|-----------------------------------------------------------|----------------------------------------------------|
+| `DAILY`   | Day after the file date @ scheduled time                  | `2026-03-11 01:00:00`                              |
+| `WEEKLY`  | First day of the next week (configurable start day) after the file date @ scheduled time | `2026-03-16 01:00:00` (Monday start)  |
+| `MONTHLY` | First day of the next month after the file date @ scheduled time | `2026-04-01 01:00:00`                       |
 
-**Important**: This strategy is designed specifically for daily files where the date in the filename represents that specific day. The file will be completed the **next day** at the scheduled time to ensure all data for that day is collected.
+**Use Case**: Long-lived files that are continuously appended over a day, a week, or a month and should only be marked as complete once that period has ended.
+
+This strategy also implements a **read back-off** mechanism: when the scheduled completion time has not yet been reached and the file has not been modified since the last read, the connector defers the next read attempt. This avoids unnecessary polling of files that are not expected to have new data yet.
+
+> **Note**: All times are resolved using the **system default timezone** of the JVM running the connector.
 
 #### Configuration
 
-| Configuration                          | Description                                                                      | Type     | Default                   | Importance |
-|----------------------------------------|----------------------------------------------------------------------------------|----------|---------------------------|------------|
-| `daily.completion.schedule.time`       | The time of day to complete files (format: HH:mm:ss)                            | string   | `00:01:00`                | high       |
-| `daily.completion.schedule.date.pattern` | Regex pattern to extract date from filename (must contain one capturing group)   | string   | `.*?(\d{4}-\d{2}-\d{2}).*` | high       |
-| `daily.completion.schedule.date.format` | Date format pattern for parsing the extracted date                              | string   | `yyyy-MM-dd`              | high       |
+| Configuration                         | Description                                                                                          | Type   | Default                       | Importance |
+|---------------------------------------|------------------------------------------------------------------------------------------------------|--------|-------------------------------|------------|
+| `completion.schedule.period`          | Period granularity: `DAILY`, `WEEKLY`, or `MONTHLY`.                                                | string | `DAILY`                       | high       |
+| `completion.schedule.time`            | Time of day at which to mark the file as COMPLETED (format: `HH:mm:ss`).                           | string | `00:01:00`                    | high       |
+| `completion.schedule.date.pattern`    | Regex pattern to extract the date from the filename. Must contain exactly one capturing group.       | string | `.*?(\d{4}-\d{2}-\d{2}).*`   | high       |
+| `completion.schedule.date.format`     | `DateTimeFormatter` pattern used to parse the date captured by the regex group.                     | string | `yyyy-MM-dd`                  | high       |
+| `completion.schedule.week.start.day`  | First day of the week used by the `WEEKLY` period when no day field is present in the date format. Accepted values: `MONDAY`, `TUESDAY`, `WEDNESDAY`, `THURSDAY`, `FRIDAY`, `SATURDAY`, `SUNDAY`. | string | `MONDAY` | low |
 
-**Note**: The strategy uses the system default timezone
+#### Examples
 
-#### Example Configuration
+**Daily** — complete daily log files (e.g. log-2026-03-25.log) the next day at 01:00:
 
 ```json
 {
-  "name": "daily-logs-connector",
-  "connector.class": "io.streamthoughts.kafka.connect.filepulse.source.FilePulseSourceConnector",
-  "fs.listing.class": "io.streamthoughts.kafka.connect.filepulse.fs.LocalFSDirectoryListing",
-  "fs.listing.directory.path": "/logs",
-  "fs.listing.filters": "io.streamthoughts.kafka.connect.filepulse.fs.filter.RegexFileListFilter",
-  "file.filter.regex.pattern": "app-\\d{4}-\\d{2}-\\d{2}\\.log",
-  
-  "fs.completion.strategy.class": "io.streamthoughts.kafka.connect.filepulse.source.DailyCompletionStrategy",
-  "daily.completion.schedule.time": "01:00:00",
-  "daily.completion.schedule.date.pattern": ".*?(\\d{4}-\\d{2}-\\d{2}).*",
-  "daily.completion.schedule.date.format": "yyyy-MM-dd"
+  "fs.completion.strategy.class": "io.streamthoughts.kafka.connect.filepulse.source.ScheduledCompletionStrategy",
+  "completion.schedule.period": "DAILY",
+  "completion.schedule.time": "01:00:00",
+  "completion.schedule.date.pattern": ".*?(\\d{4}-\\d{2}-\\d{2}).*",
+  "completion.schedule.date.format": "yyyy-MM-dd"
 }
 ```
+
+**Weekly** — complete weekly report files (e.g. `report-2026-W11.log`) the following Monday at 06:00:
+
+```json
+{
+  "fs.completion.strategy.class": "io.streamthoughts.kafka.connect.filepulse.source.ScheduledCompletionStrategy",
+  "completion.schedule.period": "WEEKLY",
+  "completion.schedule.time": "06:00:00",
+  "completion.schedule.date.pattern": ".*?(\\d{4}-W\\d{2}).*",
+  "completion.schedule.date.format": "YYYY-'W'ww"
+}
+```
+
+**Weekly (Sunday start)** — same as above but completing on the following Sunday at 06:00:
+
+```json
+{
+  "fs.completion.strategy.class": "io.streamthoughts.kafka.connect.filepulse.source.ScheduledCompletionStrategy",
+  "completion.schedule.period": "WEEKLY",
+  "completion.schedule.time": "06:00:00",
+  "completion.schedule.date.pattern": ".*?(\\d{4}-W\\d{2}).*",
+  "completion.schedule.date.format": "YYYY-'W'ww",
+  "completion.schedule.week.start.day": "SUNDAY"
+}
+```
+
+**Monthly** — complete monthly exports (e.g. `export-2026-03.log`) on the 1st of the next month at 02:00:
+
+```json
+{
+  "fs.completion.strategy.class": "io.streamthoughts.kafka.connect.filepulse.source.ScheduledCompletionStrategy",
+  "completion.schedule.period": "MONTHLY",
+  "completion.schedule.time": "02:00:00",
+  "completion.schedule.date.pattern": ".*?(\\d{4}-\\d{2}).*",
+  "completion.schedule.date.format": "yyyy-MM"
+}
+```
+
+> **Note on partial date formats**: formats that do not include a full date (e.g. `yyyy-MM` or `YYYY-'W'ww`) are
+> supported. The missing day field defaults to `1` (first day of the month for `MONTHLY`, or the configured
+> `completion.schedule.week.start.day` — Monday by default — for `WEEKLY`), which is sufficient for the
+> period boundary calculation.
+
+---
+
+### 3. DailyCompletionStrategy *(Deprecated)*
+
+> ⚠️ **Deprecated** — use [`ScheduledCompletionStrategy`](#2-scheduledcompletionstrategy) with `completion.schedule.period=DAILY` instead.
+
+`DailyCompletionStrategy` is kept for backward compatibility. It behaves identically to `ScheduledCompletionStrategy` with `DAILY` period and transparently remaps the legacy `daily.completion.schedule.*` config keys to the new `completion.schedule.*` keys — so **existing connector configurations require no change**.
+
+#### Legacy configuration keys (still accepted)
+
+| Legacy key                              | Maps to                              |
+|-----------------------------------------|--------------------------------------|
+| `daily.completion.schedule.time`        | `completion.schedule.time`           |
+| `daily.completion.schedule.date.pattern`| `completion.schedule.date.pattern`   |
+| `daily.completion.schedule.date.format` | `completion.schedule.date.format`    |
+
+#### Migration
+
+Replace the class and rename the config keys:
+
+```json
+{
+  "fs.completion.strategy.class": "io.streamthoughts.kafka.connect.filepulse.source.ScheduledCompletionStrategy",
+  "completion.schedule.period": "DAILY",
+  "completion.schedule.time": "01:00:00",
+  "completion.schedule.date.pattern": ".*?(\\d{4}-\\d{2}-\\d{2}).*",
+  "completion.schedule.date.format": "yyyy-MM-dd"
+}
+```
+
+---
+
+## Implementing a Custom Strategy
+
+You can implement your own strategy by implementing the `FileCompletionStrategy` interface:
+
+```java
+public interface FileCompletionStrategy {
+
+    default void configure(Map<String, ?> configs) { }
+
+    boolean shouldComplete(FileObjectContext context);
+}
+```
+
+Optionally, also implement `LongLivedFileReadStrategy` to control whether the connector should attempt to read from the file at a given moment (useful to avoid unnecessary polling):
+
+```java
+public interface LongLivedFileReadStrategy {
+
+    default boolean shouldAttemptRead(FileObjectMeta objectMeta, FileObjectOffset offset) {
+        return objectMeta.lastModified() > offset.timestamp();
+    }
+}
+```
+
+Set your implementation class on the `fs.completion.strategy.class` connector property.


### PR DESCRIPTION
This PR introduces a new generic `ScheduledCompletionStrategy` that supersedes the existing `DailyCompletionStrategy`, which is now **deprecated**. The new strategy supports three period granularities — `DAILY`, `WEEKLY`, and `MONTHLY` — under a single, unified configuration interface.

## Motivation

`DailyCompletionStrategy` was hard-coded for daily files only. Users working with weekly reports or monthly exports had no built-in strategy to defer completion until the end of the relevant period. Rather than duplicating the implementation into separate `WeeklyCompletionStrategy` and `MonthlyCompletionStrategy` classes, we introduce a single configurable strategy that covers all three use cases.

## Changes

### New: `ScheduledCompletionStrategy`

A generic `FileCompletionStrategy` (also implementing `LongLivedFileReadStrategy`) that:

1. Extracts a date from the filename using a configurable regex pattern and `DateTimeFormatter`.
2. Computes the next period boundary (`DAILY` → next day, `WEEKLY` → next week start, `MONTHLY` → first day of next month).
3. Marks the file as `COMPLETED` when `now >= nextPeriodBoundary @ scheduledTime`.

#### New configuration keys

| Key | Description | Default |
|-----|-------------|---------|
| `completion.schedule.period` | `DAILY`, `WEEKLY`, or `MONTHLY` | `DAILY` |
| `completion.schedule.time` | Time of day to complete (`HH:mm:ss`) | `00:01:00` |
| `completion.schedule.date.pattern` | Regex with one capturing group for the date | `.*?(\d{4}-\d{2}-\d{2}).*` |
| `completion.schedule.date.format` | `DateTimeFormatter` pattern for the captured date | `yyyy-MM-dd` |
| `completion.schedule.week.start.day` | First day of the week for `WEEKLY` period | `MONDAY` |

#### Partial date format support

Formats without a full date are supported:

- **`WEEKLY`** with `YYYY-'W'ww` — day defaults to the configured `week.start.day`
- **`WEEKLY`** with `ww` only — year defaults to the current ISO week-based year at parse time
- **`MONTHLY`** with `yyyy-MM` — day defaults to 1
- **`MONTHLY`** with `MM` or `MMM` — year defaults to the current calendar year 

### Deprecated: `DailyCompletionStrategy`

`DailyCompletionStrategy` is kept for **full backward compatibility**. It transparently remaps the legacy `daily.completion.schedule.*` config keys to the new `completion.schedule.*` keys and delegates to `ScheduledCompletionStrategy` with `period=DAILY`.

Fully backward compatible. `DailyCompletionStrategy` users are not required to migrate.
