### PR TITLE
Add support of logical types

### DIFF
--- a/connect-file-pulse-api/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/internal/ConnectSchemaMapper.java
+++ b/connect-file-pulse-api/src/main/java/io/streamthoughts/kafka/connect/filepulse/source/internal/ConnectSchemaMapper.java
@@ -26,11 +26,14 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.data.Time;
+import org.apache.kafka.connect.data.Timestamp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -259,6 +262,7 @@ public class ConnectSchemaMapper implements SchemaMapper<Schema>, SchemaMapperWi
                 }
             }
             connectStruct.put(connectField, toConnectObject(connectFieldSchema, typed));
+
         }
         return connectStruct;
     }
@@ -312,6 +316,27 @@ public class ConnectSchemaMapper implements SchemaMapper<Schema>, SchemaMapperWi
                     })
                     .collect(Collectors.toList());
         }
+
+        // Handle Connect logical types that require a java.util.Date even though their wire type is numeric.
+        //
+        // ConnectSchema.validateValue() enforces java.util.Date for all three logical types,
+        // regardless of the raw numeric type stored in the FilePulse TypedValue.
+        // We delegate to Kafka's own toLogical() helpers to guarantee identical conversion semantics:
+        //   - Timestamp (INT64): millis since epoch    → Timestamp.toLogical(schema, millis)
+        //   - Time      (INT64): millis since midnight → Time.toLogical(schema, millis)
+        //   - Date      (INT32): days since epoch      → Date.toLogical(schema, days)
+        final String schemaName = schema.name();
+        if (schemaName != null && typed.value() instanceof Number) {
+            switch (schemaName) {
+                case Timestamp.LOGICAL_NAME:
+                    return Timestamp.toLogical(schema, ((Number) typed.value()).longValue());
+                case Time.LOGICAL_NAME:
+                    return Time.toLogical(schema, ((Number) typed.value()).intValue());
+                case Date.LOGICAL_NAME:
+                    return Date.toLogical(schema, ((Number) typed.value()).intValue());
+            }
+        }
+
         return typed.value();
     }
 }

--- a/connect-file-pulse-api/src/test/java/io/streamthoughts/kafka/connect/filepulse/source/internal/ConnectSchemaMapperTest.java
+++ b/connect-file-pulse-api/src/test/java/io/streamthoughts/kafka/connect/filepulse/source/internal/ConnectSchemaMapperTest.java
@@ -11,8 +11,12 @@ import io.streamthoughts.kafka.connect.filepulse.data.TypedStruct;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.data.Time;
+import org.apache.kafka.connect.data.Timestamp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -252,5 +256,65 @@ class ConnectSchemaMapperTest {
         org.apache.kafka.connect.data.Schema mapSchema = schemaAndValue.schema().field("array").schema();
         Assertions.assertEquals(org.apache.kafka.connect.data.Schema.Type.ARRAY, mapSchema.schema().type());
         Assertions.assertEquals(org.apache.kafka.connect.data.Schema.Type.STRING, mapSchema.schema().valueSchema().type());
+    }
+
+    @Test
+    void should_convert_long_to_date_when_connect_schema_is_timestamp() {
+        // GIVEN
+        final long millis = 1711756800000L; // 2024-03-30T00:00:00Z
+        final org.apache.kafka.connect.data.Schema connectSchema = SchemaBuilder.struct()
+                .field("ts", Timestamp.builder().optional().build())
+                .build();
+        final TypedStruct struct = TypedStruct.create().put("ts", millis);
+
+        // WHEN
+        final SchemaAndValue result = mapper.map(connectSchema, struct);
+
+        // THEN
+        final Struct connectStruct = (Struct) result.value();
+        final Object value = connectStruct.get("ts");
+        Assertions.assertInstanceOf(java.util.Date.class, value,
+                "Expected java.util.Date for Timestamp logical type, got: " + value.getClass());
+        Assertions.assertEquals(new java.util.Date(millis), value);
+    }
+
+    @Test
+    void should_convert_integer_to_date_when_connect_schema_is_time() {
+        // GIVEN
+        final int millis = 36000000; // 10:00:00 AM in millis
+        final org.apache.kafka.connect.data.Schema connectSchema = SchemaBuilder.struct()
+                .field("t", Time.builder().optional().build())
+                .build();
+        final TypedStruct struct = TypedStruct.create().put("t", millis);
+
+        // WHEN
+        final SchemaAndValue result = mapper.map(connectSchema, struct);
+
+        // THEN
+        final Struct connectStruct = (Struct) result.value();
+        final Object value = connectStruct.get("t");
+        Assertions.assertInstanceOf(java.util.Date.class, value,
+                "Expected java.util.Date for Time logical type, got: " + value.getClass());
+        Assertions.assertEquals(new java.util.Date(millis), value);
+    }
+
+    @Test
+    void should_convert_integer_to_date_when_connect_schema_is_date() {
+        // GIVEN
+        final int days = 19812;
+        final org.apache.kafka.connect.data.Schema connectSchema = SchemaBuilder.struct()
+                .field("d", Date.builder().optional().build())
+                .build();
+        final TypedStruct struct = TypedStruct.create().put("d", days);
+
+        // WHEN
+        final SchemaAndValue result = mapper.map(connectSchema, struct);
+
+        // THEN
+        final Struct connectStruct = (Struct) result.value();
+        final Object value = connectStruct.get("d");
+        Assertions.assertInstanceOf(java.util.Date.class, value,
+                "Expected java.util.Date for Date logical type, got: " + value.getClass());
+        Assertions.assertEquals(Date.toLogical(Date.SCHEMA, days), value);
     }
 }


### PR DESCRIPTION
## Problem

When using `value.connect.schema` with an Avro schema that contains a field mapped to a logical type (`Timestamp`, `Date`, `Time`), the connector throws a `DataException` at serialization time:

```
Caused by: org.apache.kafka.connect.errors.DataException:  Invalid Java object for schema "org.apache.kafka.connect.data.Timestamp"  with type INT64: class java.lang.Long for field: "myField"
    at org.apache.kafka.connect.data.ConnectSchema.validateValue(ConnectSchema.java:246)
    at org.apache.kafka.connect.data.ConnectSchema.validateValue(ConnectSchema.java:217)
    at org.apache.kafka.connect.data.Struct.put(Struct.java:216)
    at io.streamthoughts.kafka.connect.filepulse.source.internal.ConnectSchemaMapper.toConnectStruct(ConnectSchemaMapper.java:261)
    at io.streamthoughts.kafka.connect.filepulse.source.internal.ConnectSchemaMapper.map(ConnectSchemaMapper.java:202)
```

## Root cause

`ConnectSchemaMapper.toConnectObject()` returns the raw numeric value for `INT32`/`INT64` fields. However, when the Connect schema field carries a **logical type annotation**, Kafka's `ConnectSchema.validateValue()` enforces that the Java object must be a `java.util.Date`, not a raw `Long` or `Integer`, even though the underlying wire type is still numeric.

The mapper has no handling for Connect logical types. The three affected logical types are `Timestamp`, `Time` and`Date`

## Fix
In `ConnectSchemaMapper.toConnectObject()`, before returning `typed.value()`, the mapper now delegates to Kafka's own `toLogical()` helper methods to guarantee identical conversion semantics to the rest of the Connect framework

## To reproduce / test the fix

#### 1. Sample Avro schema

```json
{
  "type": "record",
  "name": "Alarm",
  "namespace": "com.example",
  "fields": [
    { "name": "alarmId",               "type": "string" },
    { "name": "alarmDescription",      "type": ["null", "string"], "default": null },
    { "name": "alarmBeginningTimestamp", "type": { "type": "long", "logicalType": "timestamp-millis" } },
    { "name": "alarmEndTimestamp",     "type": [{ "type": "long", "logicalType": "timestamp-millis" }, "null"], "default": null }
  ]
}
```

#### 2. Sample input CSV file

```csv
alarmId,alarmDescription,alarmBeginningTimestamp,alarmEndTimestamp
ALARM-001,Sensor overheat,1711756800000,1711760400000
ALARM-002,,1711843200000,
```

#### 3. Connector configuration

```json
{
  "name": "filepulse-alarm-csv",
  "config": {
    "connector.class": "io.streamthoughts.kafka.connect.filepulse.source.FilePulseSourceConnector",
    "topic": "alarms",

    "fs.listing.class": "io.streamthoughts.kafka.connect.filepulse.fs.LocalFSDirectoryListing",
    "fs.listing.directory.path": "/data/alarms/",
    "fs.listing.filters": "io.streamthoughts.kafka.connect.filepulse.fs.filter.RegexFileListFilter",
    "file.filter.regex.pattern": ".*\\.csv$",

    "tasks.reader.class": "io.streamthoughts.kafka.connect.filepulse.fs.reader.LocalRowFileInputReader",
    "fs.cleanup.policy.class": "io.streamthoughts.kafka.connect.filepulse.fs.clean.DeleteCleanupPolicy",

    "filters": "ParseCSV",
    "filters.ParseCSV.type": "io.streamthoughts.kafka.connect.filepulse.filter.CSVFilter",
    "filters.ParseCSV.columns": "alarmId:STRING;alarmDescription:STRING;alarmBeginningTimestamp:LONG;alarmEndTimestamp:LONG",
    "filters.ParseCSV.separator": ",",

    "value.connect.schema.type": "AVRO",
    "value.connect.schema": "{\"type\":\"record\",\"name\":\"Alarm\",\"namespace\":\"com.example\",\"fields\":[{\"name\":\"alarmId\",\"type\":\"string\"},{\"name\":\"alarmDescription\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"alarmBeginningTimestamp\",\"type\":{\"type\":\"long\",\"logicalType\":\"timestamp-millis\"}},{\"name\":\"alarmEndTimestamp\",\"type\":[{\"type\":\"long\",\"logicalType\":\"timestamp-millis\"},\"null\"],\"default\":null}]}",

    "tasks.file.status.storage.class": "io.streamthoughts.kafka.connect.filepulse.state.KafkaFileObjectStateBackingStore",
    "tasks.file.status.storage.topic": "connect-file-pulse-status",

    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
    "value.converter": "io.confluent.connect.avro.AvroConverter",
    "value.converter.schema.registry.url": "http://schema-registry:8081"
  }
}
```

Fix #665