### PR TITLE
feat(cleanup-api): add support for multipart copy on AWS S3 move cleanup

### DIFF
--- a/connect-file-pulse-api/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/FileSystemListing.java
+++ b/connect-file-pulse-api/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/FileSystemListing.java
@@ -14,7 +14,7 @@ import org.apache.kafka.common.Configurable;
 /**
  * The {@code FileSystemListing} is used to list the object files that exists under a specific file-system.
  */
-public interface FileSystemListing<T extends Storage> extends StorageProvider<T>, Configurable {
+public interface FileSystemListing<T extends Storage> extends StorageProvider<T>, Configurable, AutoCloseable {
 
     /**
      * Configure this class with the given key-value pairs
@@ -36,5 +36,8 @@ public interface FileSystemListing<T extends Storage> extends StorageProvider<T>
     void setFilter(final FileListFilter filter);
 
 
-
+    /**
+     * Releases any resources held by this {@code FileSystemListing}.
+     */
+    default void close() {}
 }

--- a/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/AmazonS3FileSystemListing.java
+++ b/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/AmazonS3FileSystemListing.java
@@ -128,4 +128,14 @@ public class AmazonS3FileSystemListing implements FileSystemListing<AmazonS3Stor
     public AmazonS3Storage storage() {
         return s3Storage;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void close() {
+        if (this.s3Storage != null) {
+            this.s3Storage.close();
+        }
+    }
 }

--- a/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/AmazonS3FileSystemListing.java
+++ b/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/AmazonS3FileSystemListing.java
@@ -42,14 +42,15 @@ public class AmazonS3FileSystemListing implements FileSystemListing<AmazonS3Stor
      */
     @Override
     public void configure(final Map<String, ?> configs) {
-        configure(new AmazonS3ClientConfig(configs), null);
+        configure(configs, null);
     }
 
     @VisibleForTesting
-    void configure(final AmazonS3ClientConfig config, final String url) {
-        this.config = config;
+    void configure(final Map<String, ?> configs, final String url) {
+        this.config = new AmazonS3ClientConfig(configs);
         this.client = AmazonS3ClientUtils.createS3Client(config, url);
         this.s3Storage = new AmazonS3Storage(client);
+        this.s3Storage.configure(configs);
         this.s3Storage.setDefaultStorageClass(config.getAwsS3DefaultStorageClass());
         if (!s3Storage.doesS3BucketExist(config.getAwsS3BucketName())) {
             throw new ConfigException(

--- a/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/AmazonS3Storage.java
+++ b/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/AmazonS3Storage.java
@@ -10,18 +10,25 @@ import com.amazonaws.AmazonServiceException;
 import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3URI;
+import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
 import com.amazonaws.services.s3.model.CopyObjectRequest;
-import com.amazonaws.services.s3.model.CopyObjectResult;
+import com.amazonaws.services.s3.model.CopyPartRequest;
 import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
 import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PartETag;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.amazonaws.services.s3.model.StorageClass;
 import io.streamthoughts.kafka.connect.filepulse.source.FileObjectMeta;
 import io.streamthoughts.kafka.connect.filepulse.source.GenericFileObjectMeta;
 import java.io.InputStream;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import org.slf4j.Logger;
@@ -37,6 +44,13 @@ public class AmazonS3Storage implements Storage {
     private StorageClass defaultStorageClass;
     private final AmazonS3 s3Client;
 
+    private long multipartCopyThreshold;
+    private long partSize;
+    private int maxParts;
+
+    private AmazonS3StorageConfig config;
+    
+
     /**
      * Creates a new {@link AmazonS3Storage} instance.
      *
@@ -44,6 +58,17 @@ public class AmazonS3Storage implements Storage {
      */
     public AmazonS3Storage(final AmazonS3 s3Client) {
         this.s3Client = Objects.requireNonNull(s3Client, "s3Client should not be null");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void configure(final Map<String, ?> configs) {
+        this.config = new AmazonS3StorageConfig(configs);
+        this.multipartCopyThreshold = this.config.getMultipartCopyThresholdConfig();
+        this.partSize = this.config.getPartSizeConfig();
+        this.maxParts = this.config.getMaxPartsConfig();
     }
 
     public void setDefaultStorageClass(final StorageClass defaultStorageClass) {
@@ -117,9 +142,19 @@ public class AmazonS3Storage implements Storage {
                     "Copying S3 object from {} to {}",
                     s3SourceObject.toURI(),
                     s3DestinationObject.toURI()
-                    );
-            CopyObjectResult objectResult = this.s3Client.copyObject(copyObjectRequest);
-            if (objectResult.getETag() != null) {
+            );
+
+            long fileSizeInBytes = objectMetadata.getContentLength();
+
+            String copyResultETag;
+
+            if (fileSizeInBytes < this.multipartCopyThreshold) {
+                copyResultETag = this.s3Client.copyObject(copyObjectRequest).getETag();
+            } else {
+                copyResultETag = performMultipartCopy(s3SourceObject, s3DestinationObject, objectMetadata);
+            }
+
+            if (copyResultETag != null) {
                 LOG.debug("Deleting S3 object: {}", s3SourceObject.toURI());
                 return delete(s3SourceObject.toURI());
             }
@@ -142,6 +177,67 @@ public class AmazonS3Storage implements Storage {
             );
         }
         return false;
+    }
+
+    private String performMultipartCopy(
+            S3BucketKey s3SourceObject,
+            S3BucketKey s3DestinationObject,
+            ObjectMetadata objectMetadata
+    ) {
+        long fileSizeInBytes = objectMetadata.getContentLength();
+        long partsCount = (fileSizeInBytes + this.partSize - 1) / this.partSize;
+
+        long finalPartSize = this.partSize;
+
+        if (partsCount > this.maxParts) {
+            finalPartSize = (fileSizeInBytes + this.maxParts - 1) / this.maxParts;
+            LOG.warn(
+                    "Configured parts.size of {} bytes would result in {} parts, exceeding parts.max {}. " +
+                            "Ignoring configured parts.size and recalculating to {} bytes per part.",
+                    this.partSize, partsCount, this.maxParts, finalPartSize
+            );
+            partsCount = this.maxParts;
+        }
+
+        LOG.debug("Performing multipart copy in {} parts of {} bytes each", partsCount, finalPartSize);
+
+        InitiateMultipartUploadResult initiateMultipartUploadResult = this.s3Client.initiateMultipartUpload(
+                new InitiateMultipartUploadRequest(
+                        s3DestinationObject.bucketName(),
+                        s3DestinationObject.key(),
+                        objectMetadata
+                )
+        );
+
+        List<PartETag> copiedParts = new ArrayList<>();
+
+        for (int i = 0; i < partsCount; i++) {
+            long offsetBegin = i * finalPartSize;
+            // For last part we cant go further than fileSize
+            long offsetEnd = Math.min(offsetBegin + finalPartSize, fileSizeInBytes) - 1;
+
+            copiedParts.add(this.s3Client.copyPart(
+                    new CopyPartRequest()
+                            .withSourceBucketName(s3SourceObject.bucketName())
+                            .withSourceKey(s3SourceObject.key())
+                            .withDestinationBucketName(s3DestinationObject.bucketName())
+                            .withDestinationKey(s3DestinationObject.key())
+                            .withUploadId(initiateMultipartUploadResult.getUploadId())
+                            // Part numbers start at 1
+                            .withPartNumber(i + 1)
+                            .withFirstByte(offsetBegin)
+                            .withLastByte(offsetEnd)
+            ).getPartETag());
+        }
+
+        return this.s3Client.completeMultipartUpload(
+                new CompleteMultipartUploadRequest(
+                        s3DestinationObject.bucketName(),
+                        s3DestinationObject.key(),
+                        initiateMultipartUploadResult.getUploadId(),
+                        copiedParts
+                )
+        ).getETag();
     }
 
     /**

--- a/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/AmazonS3Storage.java
+++ b/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/AmazonS3Storage.java
@@ -33,15 +33,14 @@ import org.slf4j.LoggerFactory;
 /**
  * The {@code AmazonS3Storage} can be used to interact with Amazon S3.
  */
-public class AmazonS3Storage implements Storage {
+public class AmazonS3Storage implements Storage, AutoCloseable {
 
     private static final Logger LOG = LoggerFactory.getLogger(AmazonS3Storage.class);
 
     private StorageClass defaultStorageClass;
     private final AmazonS3 s3Client;
 
-    private long multipartCopyThreshold;
-    private long partSize;
+    private TransferManager transferManager;
 
     /**
      * Creates a new {@link AmazonS3Storage} instance.
@@ -58,8 +57,13 @@ public class AmazonS3Storage implements Storage {
     @Override
     public void configure(final Map<String, ?> configs) {
         AmazonS3StorageConfig storageConfig = new AmazonS3StorageConfig(configs);
-        this.multipartCopyThreshold = storageConfig.getMultipartCopyThresholdConfig();
-        this.partSize = storageConfig.getPartSizeConfig();
+        this.transferManager = TransferManagerBuilder.standard()
+                .withS3Client(s3Client)
+                .withExecutorFactory(Executors::newCachedThreadPool)
+                // Only use multipart copy when fileSize > multipartCopyThreshold
+                .withMultipartCopyThreshold(storageConfig.getMultipartCopyThresholdConfig())
+                .withMultipartCopyPartSize(storageConfig.getPartSizeConfig())
+                .build();
     }
 
     public void setDefaultStorageClass(final StorageClass defaultStorageClass) {
@@ -107,14 +111,6 @@ public class AmazonS3Storage implements Storage {
         final S3BucketKey s3SourceObject = S3BucketKey.fromURI(source);
         final S3BucketKey s3DestinationObject = S3BucketKey.fromURI(dest);
 
-        TransferManager transferManager = TransferManagerBuilder.standard()
-                .withS3Client(s3Client)
-                .withExecutorFactory(() -> Executors.newFixedThreadPool(1))
-                // Only use multipart copy when fileSize > multipartCopyThreshold
-                .withMultipartCopyThreshold(this.multipartCopyThreshold)
-                .withMultipartCopyPartSize(this.partSize)
-                .build();
-
         try {
             // AWS S3 does not support built-in move operation.
             // Move should be implemented as copy+delete
@@ -144,7 +140,7 @@ public class AmazonS3Storage implements Storage {
                     s3DestinationObject.toURI()
             );
 
-            String copyResultETag = transferManager
+            String copyResultETag = this.transferManager
                     .copy(copyObjectRequest)
                     .waitForCopyResult()
                     .getETag();
@@ -177,8 +173,6 @@ public class AmazonS3Storage implements Storage {
                     s3SourceObject.toURI(),
                     s3DestinationObject.toURI()
             );
-        } finally {
-            transferManager.shutdownNow(false);
         }
         return false;
     }
@@ -336,5 +330,12 @@ public class AmazonS3Storage implements Storage {
                 .withLastModified(s3ObjectSummary.getLastModified())
                 .withContentDigest(digest)
                 .build();
+    }
+
+    @Override
+    public void close() {
+        if (this.transferManager != null) {
+            transferManager.shutdownNow(false);
+        }
     }
 }

--- a/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/AmazonS3Storage.java
+++ b/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/AmazonS3Storage.java
@@ -10,27 +10,23 @@ import com.amazonaws.AmazonServiceException;
 import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3URI;
-import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
 import com.amazonaws.services.s3.model.CopyObjectRequest;
-import com.amazonaws.services.s3.model.CopyPartRequest;
 import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
 import com.amazonaws.services.s3.model.GetObjectRequest;
-import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
-import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
 import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.PartETag;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.amazonaws.services.s3.model.StorageClass;
+import com.amazonaws.services.s3.transfer.TransferManager;
+import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
 import io.streamthoughts.kafka.connect.filepulse.source.FileObjectMeta;
 import io.streamthoughts.kafka.connect.filepulse.source.GenericFileObjectMeta;
 import java.io.InputStream;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.Executors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,10 +42,6 @@ public class AmazonS3Storage implements Storage {
 
     private long multipartCopyThreshold;
     private long partSize;
-    private int maxParts;
-
-    private AmazonS3StorageConfig config;
-    
 
     /**
      * Creates a new {@link AmazonS3Storage} instance.
@@ -65,10 +57,9 @@ public class AmazonS3Storage implements Storage {
      */
     @Override
     public void configure(final Map<String, ?> configs) {
-        this.config = new AmazonS3StorageConfig(configs);
-        this.multipartCopyThreshold = this.config.getMultipartCopyThresholdConfig();
-        this.partSize = this.config.getPartSizeConfig();
-        this.maxParts = this.config.getMaxPartsConfig();
+        AmazonS3StorageConfig storageConfig = new AmazonS3StorageConfig(configs);
+        this.multipartCopyThreshold = storageConfig.getMultipartCopyThresholdConfig();
+        this.partSize = storageConfig.getPartSizeConfig();
     }
 
     public void setDefaultStorageClass(final StorageClass defaultStorageClass) {
@@ -115,6 +106,15 @@ public class AmazonS3Storage implements Storage {
     public boolean move(final URI source, final URI dest) {
         final S3BucketKey s3SourceObject = S3BucketKey.fromURI(source);
         final S3BucketKey s3DestinationObject = S3BucketKey.fromURI(dest);
+
+        TransferManager transferManager = TransferManagerBuilder.standard()
+                .withS3Client(s3Client)
+                .withExecutorFactory(() -> Executors.newFixedThreadPool(1))
+                // Only use multipart copy when fileSize > multipartCopyThreshold
+                .withMultipartCopyThreshold(this.multipartCopyThreshold)
+                .withMultipartCopyPartSize(this.partSize)
+                .build();
+
         try {
             // AWS S3 does not support built-in move operation.
             // Move should be implemented as copy+delete
@@ -144,15 +144,10 @@ public class AmazonS3Storage implements Storage {
                     s3DestinationObject.toURI()
             );
 
-            long fileSizeInBytes = objectMetadata.getContentLength();
-
-            String copyResultETag;
-
-            if (fileSizeInBytes < this.multipartCopyThreshold) {
-                copyResultETag = this.s3Client.copyObject(copyObjectRequest).getETag();
-            } else {
-                copyResultETag = performMultipartCopy(s3SourceObject, s3DestinationObject, objectMetadata);
-            }
+            String copyResultETag = transferManager
+                    .copy(copyObjectRequest)
+                    .waitForCopyResult()
+                    .getETag();
 
             if (copyResultETag != null) {
                 LOG.debug("Deleting S3 object: {}", s3SourceObject.toURI());
@@ -175,69 +170,17 @@ public class AmazonS3Storage implements Storage {
                     s3SourceObject.toURI(),
                     e
             );
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.error(
+                    "Interrupted while waiting for S3 copy from {} to {}",
+                    s3SourceObject.toURI(),
+                    s3DestinationObject.toURI()
+            );
+        } finally {
+            transferManager.shutdownNow(false);
         }
         return false;
-    }
-
-    private String performMultipartCopy(
-            S3BucketKey s3SourceObject,
-            S3BucketKey s3DestinationObject,
-            ObjectMetadata objectMetadata
-    ) {
-        long fileSizeInBytes = objectMetadata.getContentLength();
-        long partsCount = (fileSizeInBytes + this.partSize - 1) / this.partSize;
-
-        long finalPartSize = this.partSize;
-
-        if (partsCount > this.maxParts) {
-            finalPartSize = (fileSizeInBytes + this.maxParts - 1) / this.maxParts;
-            LOG.warn(
-                    "Configured parts.size of {} bytes would result in {} parts, exceeding parts.max {}. " +
-                            "Ignoring configured parts.size and recalculating to {} bytes per part.",
-                    this.partSize, partsCount, this.maxParts, finalPartSize
-            );
-            partsCount = this.maxParts;
-        }
-
-        LOG.debug("Performing multipart copy in {} parts of {} bytes each", partsCount, finalPartSize);
-
-        InitiateMultipartUploadResult initiateMultipartUploadResult = this.s3Client.initiateMultipartUpload(
-                new InitiateMultipartUploadRequest(
-                        s3DestinationObject.bucketName(),
-                        s3DestinationObject.key(),
-                        objectMetadata
-                )
-        );
-
-        List<PartETag> copiedParts = new ArrayList<>();
-
-        for (int i = 0; i < partsCount; i++) {
-            long offsetBegin = i * finalPartSize;
-            // For last part we cant go further than fileSize
-            long offsetEnd = Math.min(offsetBegin + finalPartSize, fileSizeInBytes) - 1;
-
-            copiedParts.add(this.s3Client.copyPart(
-                    new CopyPartRequest()
-                            .withSourceBucketName(s3SourceObject.bucketName())
-                            .withSourceKey(s3SourceObject.key())
-                            .withDestinationBucketName(s3DestinationObject.bucketName())
-                            .withDestinationKey(s3DestinationObject.key())
-                            .withUploadId(initiateMultipartUploadResult.getUploadId())
-                            // Part numbers start at 1
-                            .withPartNumber(i + 1)
-                            .withFirstByte(offsetBegin)
-                            .withLastByte(offsetEnd)
-            ).getPartETag());
-        }
-
-        return this.s3Client.completeMultipartUpload(
-                new CompleteMultipartUploadRequest(
-                        s3DestinationObject.bucketName(),
-                        s3DestinationObject.key(),
-                        initiateMultipartUploadResult.getUploadId(),
-                        copiedParts
-                )
-        ).getETag();
     }
 
     /**

--- a/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/AmazonS3StorageConfig.java
+++ b/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/AmazonS3StorageConfig.java
@@ -14,7 +14,7 @@ public class AmazonS3StorageConfig extends AbstractConfig {
 
     private static final String CONFIG_GROUP = "AmazonS3Storage";
 
-    private static final String CONFIG_PREFIX = "fs.cleanup.policy.move.aws.";
+    private static final String CONFIG_PREFIX = "fs.s3.transfer.";
 
     public static final String MULTIPART_COPY_THRESHOLD_CONFIG = CONFIG_PREFIX + "multipart.threshold";
     private static final String MULTIPART_COPY_THRESHOLD_CONFIG_DOC =

--- a/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/AmazonS3StorageConfig.java
+++ b/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/AmazonS3StorageConfig.java
@@ -21,17 +21,14 @@ public class AmazonS3StorageConfig extends AbstractConfig {
             "File size threshold in bytes above which a multipart copy will be used instead of a single-part copy";
     private static final long MULTIPART_COPY_THRESHOLD_CONFIG_DEFAULT = 1024*1024*1024*5L; //5 GB
     private static final ConfigDef.Validator MULTIPART_COPY_THRESHOLD_CONFIG_VALIDATOR
-            = ConfigDef.Range.between(5 * 1024 * 1024L, 5L * 1024 * 1024 * 1024); // between 5 MB and 5 GB
+            = ConfigDef.Range.between(5L * 1024 * 1024L, 5L * 1024 * 1024 * 1024); // between 5 MB and 5 GB
 
     public static final String PART_SIZE_CONFIG = CONFIG_PREFIX + "parts.size";
-    private static final String PART_SIZE_CONFIG_DOC = "Size in bytes of each part when performing a multipart copy";
+    private static final String PART_SIZE_CONFIG_DOC = "Minimum size in bytes of each part in a multipart copy. May be " +
+            "adjusted upward to stay within S3's 10000 parts limit.";
     private static final long PART_SIZE_CONFIG_DEFAULT = 100*1024*1024; //100 MB
-    private static final ConfigDef.Validator PART_SIZE_CONFIG_VALIDATOR = ConfigDef.Range.atLeast(5 * 1024 * 1024L);
-
-    public static final String MAX_PARTS_CONFIG = CONFIG_PREFIX + "parts.max";
-    private static final String MAX_PARTS_CONFIG_DOC = "Maximum number of parts allowed in a multipart copy operation";
-    private static final int MAX_PARTS_CONFIG_DEFAULT = 10_000;
-    private static final ConfigDef.Validator MAX_PARTS_CONFIG_VALIDATOR = ConfigDef.Range.between(1, 10_000);
+    private static final ConfigDef.Validator PART_SIZE_CONFIG_VALIDATOR
+            = ConfigDef.Range.between(5 * 1024 * 1024L, 5L * 1024 * 1024 * 1024); // between 5 MB and 5 GB
 
     public long getMultipartCopyThresholdConfig() {
         return getLong(MULTIPART_COPY_THRESHOLD_CONFIG);
@@ -39,10 +36,6 @@ public class AmazonS3StorageConfig extends AbstractConfig {
 
     public long getPartSizeConfig() {
         return getLong(PART_SIZE_CONFIG);
-    }
-
-    public int getMaxPartsConfig() {
-        return getInt(MAX_PARTS_CONFIG);
     }
 
     /**
@@ -78,18 +71,6 @@ public class AmazonS3StorageConfig extends AbstractConfig {
                         groupCounter++,
                         ConfigDef.Width.NONE,
                         PART_SIZE_CONFIG
-                )
-                .define(
-                        MAX_PARTS_CONFIG,
-                        ConfigDef.Type.INT,
-                        MAX_PARTS_CONFIG_DEFAULT,
-                        MAX_PARTS_CONFIG_VALIDATOR,
-                        ConfigDef.Importance.HIGH,
-                        MAX_PARTS_CONFIG_DOC,
-                        CONFIG_GROUP,
-                        groupCounter++,
-                        ConfigDef.Width.NONE,
-                        MAX_PARTS_CONFIG
                 );
     }
 }

--- a/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/AmazonS3StorageConfig.java
+++ b/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/AmazonS3StorageConfig.java
@@ -1,0 +1,95 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) StreamThoughts
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.streamthoughts.kafka.connect.filepulse.fs;
+
+import java.util.Map;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+
+public class AmazonS3StorageConfig extends AbstractConfig {
+
+    private static final String CONFIG_GROUP = "AmazonS3Storage";
+
+    private static final String CONFIG_PREFIX = "fs.cleanup.policy.move.aws.";
+
+    public static final String MULTIPART_COPY_THRESHOLD_CONFIG = CONFIG_PREFIX + "multipart.threshold";
+    private static final String MULTIPART_COPY_THRESHOLD_CONFIG_DOC =
+            "File size threshold in bytes above which a multipart copy will be used instead of a single-part copy";
+    private static final long MULTIPART_COPY_THRESHOLD_CONFIG_DEFAULT = 1024*1024*1024*5L; //5 GB
+    private static final ConfigDef.Validator MULTIPART_COPY_THRESHOLD_CONFIG_VALIDATOR
+            = ConfigDef.Range.between(5 * 1024 * 1024L, 5L * 1024 * 1024 * 1024); // between 5 MB and 5 GB
+
+    public static final String PART_SIZE_CONFIG = CONFIG_PREFIX + "parts.size";
+    private static final String PART_SIZE_CONFIG_DOC = "Size in bytes of each part when performing a multipart copy";
+    private static final long PART_SIZE_CONFIG_DEFAULT = 100*1024*1024; //100 MB
+    private static final ConfigDef.Validator PART_SIZE_CONFIG_VALIDATOR = ConfigDef.Range.atLeast(5 * 1024 * 1024L);
+
+    public static final String MAX_PARTS_CONFIG = CONFIG_PREFIX + "parts.max";
+    private static final String MAX_PARTS_CONFIG_DOC = "Maximum number of parts allowed in a multipart copy operation";
+    private static final int MAX_PARTS_CONFIG_DEFAULT = 10_000;
+    private static final ConfigDef.Validator MAX_PARTS_CONFIG_VALIDATOR = ConfigDef.Range.between(1, 10_000);
+
+    public long getMultipartCopyThresholdConfig() {
+        return getLong(MULTIPART_COPY_THRESHOLD_CONFIG);
+    }
+
+    public long getPartSizeConfig() {
+        return getLong(PART_SIZE_CONFIG);
+    }
+
+    public int getMaxPartsConfig() {
+        return getInt(MAX_PARTS_CONFIG);
+    }
+
+    /**
+     * Creates a new {@link AmazonS3StorageConfig} instance.
+     */
+    public AmazonS3StorageConfig(final Map<?, ?> originals) {
+        super(configDef(), originals, true);
+    }
+
+    static ConfigDef configDef() {
+        int groupCounter = 0;
+        return new ConfigDef()
+                .define(
+                        MULTIPART_COPY_THRESHOLD_CONFIG,
+                        ConfigDef.Type.LONG,
+                        MULTIPART_COPY_THRESHOLD_CONFIG_DEFAULT,
+                        MULTIPART_COPY_THRESHOLD_CONFIG_VALIDATOR,
+                        ConfigDef.Importance.HIGH,
+                        MULTIPART_COPY_THRESHOLD_CONFIG_DOC,
+                        CONFIG_GROUP,
+                        groupCounter++,
+                        ConfigDef.Width.NONE,
+                        MULTIPART_COPY_THRESHOLD_CONFIG
+                )
+                .define(
+                        PART_SIZE_CONFIG,
+                        ConfigDef.Type.LONG,
+                        PART_SIZE_CONFIG_DEFAULT,
+                        PART_SIZE_CONFIG_VALIDATOR,
+                        ConfigDef.Importance.HIGH,
+                        PART_SIZE_CONFIG_DOC,
+                        CONFIG_GROUP,
+                        groupCounter++,
+                        ConfigDef.Width.NONE,
+                        PART_SIZE_CONFIG
+                )
+                .define(
+                        MAX_PARTS_CONFIG,
+                        ConfigDef.Type.INT,
+                        MAX_PARTS_CONFIG_DEFAULT,
+                        MAX_PARTS_CONFIG_VALIDATOR,
+                        ConfigDef.Importance.HIGH,
+                        MAX_PARTS_CONFIG_DOC,
+                        CONFIG_GROUP,
+                        groupCounter++,
+                        ConfigDef.Width.NONE,
+                        MAX_PARTS_CONFIG
+                );
+    }
+}

--- a/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/reader/BaseAmazonS3InputReader.java
+++ b/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/reader/BaseAmazonS3InputReader.java
@@ -39,6 +39,7 @@ public abstract class BaseAmazonS3InputReader
             final AmazonS3ClientConfig clientConfig = new AmazonS3ClientConfig(configs);
             s3Client = AmazonS3ClientUtils.createS3Client(clientConfig);
             storage = new AmazonS3Storage(s3Client);
+            storage.configure(configs);
             storage.setDefaultStorageClass(clientConfig.getAwsS3DefaultStorageClass());
         }
     }
@@ -63,6 +64,9 @@ public abstract class BaseAmazonS3InputReader
     public void close() {
         if (s3Client != null) {
             s3Client.shutdown();
+        }
+        if (storage != null) {
+            storage.close();
         }
     }
 }

--- a/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/test/java/io/streamthoughts/kafka/connect/filepulse/fs/AmazonS3FileSystemListingTest.java
+++ b/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/test/java/io/streamthoughts/kafka/connect/filepulse/fs/AmazonS3FileSystemListingTest.java
@@ -31,9 +31,8 @@ public class AmazonS3FileSystemListingTest extends BaseAmazonS3Test {
         client.createBucket(S3_TEST_BUCKET);
         OBJECT_KEYS.forEach(key -> client.putObject(S3_TEST_BUCKET, key, "contents"));
 
-        var clientConfig = new AmazonS3ClientConfig(unmodifiableCommonsProperties);
         var listing = new AmazonS3FileSystemListing();
-        listing.configure(clientConfig, endpointConfiguration);
+        listing.configure(unmodifiableCommonsProperties, endpointConfiguration);
 
         // WHEN
         final Collection<FileObjectMeta> objects = listing.listObjects();
@@ -56,9 +55,8 @@ public class AmazonS3FileSystemListingTest extends BaseAmazonS3Test {
         var properties = new HashMap<>(unmodifiableCommonsProperties);
         properties.put(AWS_S3_BUCKET_PREFIX_CONFIG, "file/name/foo");
 
-        var clientConfig = new AmazonS3ClientConfig(properties);
         var listing = new AmazonS3FileSystemListing();
-        listing.configure(clientConfig, endpointConfiguration);
+        listing.configure(properties, endpointConfiguration);
 
         // WHEN
         final Collection<FileObjectMeta> objects = listing.listObjects();
@@ -76,11 +74,10 @@ public class AmazonS3FileSystemListingTest extends BaseAmazonS3Test {
         // GIVEN
         var properties = new HashMap<>(unmodifiableCommonsProperties);
         properties.put(AWS_S3_BUCKET_NAME_CONFIG, "dummy");
-        var clientConfig = new AmazonS3ClientConfig(properties);
 
         var listing = new AmazonS3FileSystemListing();
 
         // WHEN/THEN
-        listing.configure(clientConfig, endpointConfiguration);
+        listing.configure(properties, endpointConfiguration);
     }
 }

--- a/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/test/java/io/streamthoughts/kafka/connect/filepulse/fs/clean/AmazonS3MoveCleanupPolicyTest.java
+++ b/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/test/java/io/streamthoughts/kafka/connect/filepulse/fs/clean/AmazonS3MoveCleanupPolicyTest.java
@@ -6,16 +6,26 @@
  */
 package io.streamthoughts.kafka.connect.filepulse.fs.clean;
 
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CompleteMultipartUploadResult;
+import com.amazonaws.services.s3.model.CopyPartResult;
+import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import io.streamthoughts.kafka.connect.filepulse.fs.AmazonS3Storage;
+import io.streamthoughts.kafka.connect.filepulse.fs.AmazonS3StorageConfig;
 import io.streamthoughts.kafka.connect.filepulse.fs.BaseAmazonS3Test;
 import io.streamthoughts.kafka.connect.filepulse.fs.S3BucketKey;
 import io.streamthoughts.kafka.connect.filepulse.source.FileObject;
 import io.streamthoughts.kafka.connect.filepulse.source.FileObjectMeta;
 import io.streamthoughts.kafka.connect.filepulse.source.FileObjectOffset;
 import io.streamthoughts.kafka.connect.filepulse.source.FileObjectStatus;
+import java.io.ByteArrayInputStream;
+import java.util.HashMap;
 import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public class AmazonS3MoveCleanupPolicyTest extends BaseAmazonS3Test {
 
@@ -31,6 +41,7 @@ public class AmazonS3MoveCleanupPolicyTest extends BaseAmazonS3Test {
     public void setUp() throws Exception {
         super.setUp();
         storage = new AmazonS3Storage(client);
+        storage.configure(new HashMap<>());
     }
 
     @Test
@@ -145,5 +156,152 @@ public class AmazonS3MoveCleanupPolicyTest extends BaseAmazonS3Test {
         // THEN
         Assert.assertFalse(storage.exists(objectMetadata.uri()));
         Assert.assertTrue(storage.exists(new S3BucketKey(S3_TEST_BUCKET, "/failure/prefix/" + OBJECT_NAME).toURI()));
+    }
+
+    @Test
+    public void should_move_big_object() {
+        // GIVEN
+        client.createBucket(S3_TEST_BUCKET);
+        client.putObject(S3_TEST_BUCKET, S3_OBJECT_KEY, "contents");
+
+        AmazonS3 spyClient = Mockito.spy(client);
+        ObjectMetadata bigMetadata = new ObjectMetadata();
+        bigMetadata.setContentLength(6L * 1024 * 1024 * 1024); // 6 GB
+        Mockito.doReturn(bigMetadata)
+                .when(spyClient)
+                .getObjectMetadata(Mockito.any(GetObjectMetadataRequest.class));
+
+        InitiateMultipartUploadResult initiateMultipartUploadResult = new InitiateMultipartUploadResult();
+        initiateMultipartUploadResult.setUploadId("uploadId");
+
+        Mockito.doReturn(initiateMultipartUploadResult).when(spyClient).initiateMultipartUpload(
+                Mockito.argThat(argument ->
+                        argument.getBucketName().equals(S3_TEST_BUCKET) &&
+                        argument.getKey().equals("/success/object"))
+        );
+
+        CopyPartResult copyPartResult = new CopyPartResult();
+        copyPartResult.setETag("copy-part-etag");
+
+        Mockito.doReturn(copyPartResult).when(spyClient).copyPart(
+                Mockito.argThat(argument ->
+                        argument.getUploadId().equals("uploadId") &&
+                        argument.getSourceBucketName().equals(S3_TEST_BUCKET) &&
+                        argument.getSourceKey().equals(S3_OBJECT_KEY) &&
+                        argument.getDestinationBucketName().equals(S3_TEST_BUCKET) &&
+                        argument.getDestinationKey().equals("/success/object")
+                )
+        );
+
+        CompleteMultipartUploadResult completeMultipartUploadResult = new CompleteMultipartUploadResult();
+        completeMultipartUploadResult.setETag("complete-upload-etag");
+
+        Mockito.doReturn(completeMultipartUploadResult).when(spyClient).completeMultipartUpload(
+                Mockito.argThat(argument ->
+                        argument.getBucketName().equals(S3_TEST_BUCKET) &&
+                        argument.getKey().equals("/success/object") &&
+                        argument.getUploadId().equals("uploadId") &&
+                        argument.getPartETags().size() == 62
+                )
+        );
+
+        AmazonS3Storage bigStorage = new AmazonS3Storage(spyClient);
+        bigStorage.configure(new HashMap<>());
+
+        var cleaner = new AmazonS3MoveCleanupPolicy();
+        cleaner.setStorage(bigStorage);
+        cleaner.configure(Map.of(
+                AmazonS3MoveCleanupPolicy.Config.SUCCESS_AWS_PREFIX_PATH_CONFIG, "/success/",
+                AmazonS3MoveCleanupPolicy.Config.FAILURES_AWS_PREFIX_PATH_CONFIG, "/failure/"
+        ));
+
+        // WHEN
+        FileObjectMeta objectMetadata = storage.getObjectMetadata(new S3BucketKey(S3_TEST_BUCKET, S3_OBJECT_KEY));
+        cleaner.onSuccess(
+                new FileObject(
+                        objectMetadata,
+                        FileObjectOffset.empty(),
+                        FileObjectStatus.COMPLETED
+                )
+        );
+
+        // THEN
+        Mockito.verify(spyClient, Mockito.times(1)).initiateMultipartUpload(
+                Mockito.argThat(argument ->
+                        argument.getBucketName().equals(S3_TEST_BUCKET) &&
+                        argument.getKey().equals("/success/object")
+                )
+        );
+        Mockito.verify(spyClient, Mockito.times(62)).copyPart(
+                Mockito.argThat(argument ->
+                        argument.getUploadId().equals("uploadId") &&
+                        argument.getSourceBucketName().equals(S3_TEST_BUCKET) &&
+                        argument.getSourceKey().equals(S3_OBJECT_KEY) &&
+                        argument.getDestinationBucketName().equals(S3_TEST_BUCKET) &&
+                        argument.getDestinationKey().equals("/success/object")
+                )
+        );
+        Mockito.verify(spyClient, Mockito.times(1)).completeMultipartUpload(
+                Mockito.argThat(argument ->
+                        argument.getBucketName().equals(S3_TEST_BUCKET) &&
+                        argument.getKey().equals("/success/object") &&
+                        argument.getUploadId().equals("uploadId") &&
+                        argument.getPartETags().size() == 62
+                )
+        );
+    }
+
+    @Test
+    public void should_move_object_using_multipart() {
+        // GIVEN
+        int fiveMB = 5 * 1024 * 1024 + 1;
+        AmazonS3 spyClient = Mockito.spy(client);
+        client.createBucket(S3_TEST_BUCKET);
+        byte[] content = new byte[fiveMB + 1];
+        ObjectMetadata meta = new ObjectMetadata();
+        meta.setContentLength(content.length);
+        client.putObject(S3_TEST_BUCKET, S3_OBJECT_KEY, new ByteArrayInputStream(content), meta);
+
+        AmazonS3Storage bigStorage = new AmazonS3Storage(spyClient);
+        bigStorage.configure(Map.of(
+                AmazonS3StorageConfig.MULTIPART_COPY_THRESHOLD_CONFIG, fiveMB,
+                AmazonS3StorageConfig.PART_SIZE_CONFIG, fiveMB
+        ));
+
+        var cleaner = new AmazonS3MoveCleanupPolicy();
+        cleaner.setStorage(bigStorage);
+        cleaner.configure(Map.of(
+                AmazonS3MoveCleanupPolicy.Config.SUCCESS_AWS_PREFIX_PATH_CONFIG, "/success/",
+                AmazonS3MoveCleanupPolicy.Config.FAILURES_AWS_PREFIX_PATH_CONFIG, "/failure/"
+        ));
+
+        // WHEN
+        FileObjectMeta objectMetadata = bigStorage.getObjectMetadata(new S3BucketKey(S3_TEST_BUCKET, S3_OBJECT_KEY));
+        cleaner.onSuccess(new FileObject(objectMetadata, FileObjectOffset.empty(), FileObjectStatus.COMPLETED));
+
+        // THEN
+        Assert.assertFalse(bigStorage.exists(objectMetadata.uri()));
+        Assert.assertTrue(bigStorage.exists(new S3BucketKey(S3_TEST_BUCKET, "/success/" + OBJECT_NAME).toURI()));
+        Mockito.verify(spyClient, Mockito.times(1)).initiateMultipartUpload(
+                Mockito.argThat(argument ->
+                        argument.getBucketName().equals(S3_TEST_BUCKET) &&
+                        argument.getKey().equals("/success/object")
+                )
+        );
+        Mockito.verify(spyClient, Mockito.times(2)).copyPart(
+                Mockito.argThat(argument ->
+                        argument.getSourceBucketName().equals(S3_TEST_BUCKET) &&
+                        argument.getSourceKey().equals(S3_OBJECT_KEY) &&
+                        argument.getDestinationBucketName().equals(S3_TEST_BUCKET) &&
+                        argument.getDestinationKey().equals("/success/object")
+                )
+        );
+        Mockito.verify(spyClient, Mockito.times(1)).completeMultipartUpload(
+                Mockito.argThat(argument ->
+                        argument.getBucketName().equals(S3_TEST_BUCKET) &&
+                                argument.getKey().equals("/success/object") &&
+                                argument.getPartETags().size() == 2
+                )
+        );
     }
 }

--- a/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/test/java/io/streamthoughts/kafka/connect/filepulse/fs/clean/AmazonS3MoveCleanupPolicyTest.java
+++ b/connect-file-pulse-filesystems/filepulse-amazons3-fs/src/test/java/io/streamthoughts/kafka/connect/filepulse/fs/clean/AmazonS3MoveCleanupPolicyTest.java
@@ -7,10 +7,6 @@
 package io.streamthoughts.kafka.connect.filepulse.fs.clean;
 
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.CompleteMultipartUploadResult;
-import com.amazonaws.services.s3.model.CopyPartResult;
-import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
-import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import io.streamthoughts.kafka.connect.filepulse.fs.AmazonS3Storage;
 import io.streamthoughts.kafka.connect.filepulse.fs.AmazonS3StorageConfig;
@@ -156,99 +152,6 @@ public class AmazonS3MoveCleanupPolicyTest extends BaseAmazonS3Test {
         // THEN
         Assert.assertFalse(storage.exists(objectMetadata.uri()));
         Assert.assertTrue(storage.exists(new S3BucketKey(S3_TEST_BUCKET, "/failure/prefix/" + OBJECT_NAME).toURI()));
-    }
-
-    @Test
-    public void should_move_big_object() {
-        // GIVEN
-        client.createBucket(S3_TEST_BUCKET);
-        client.putObject(S3_TEST_BUCKET, S3_OBJECT_KEY, "contents");
-
-        AmazonS3 spyClient = Mockito.spy(client);
-        ObjectMetadata bigMetadata = new ObjectMetadata();
-        bigMetadata.setContentLength(6L * 1024 * 1024 * 1024); // 6 GB
-        Mockito.doReturn(bigMetadata)
-                .when(spyClient)
-                .getObjectMetadata(Mockito.any(GetObjectMetadataRequest.class));
-
-        InitiateMultipartUploadResult initiateMultipartUploadResult = new InitiateMultipartUploadResult();
-        initiateMultipartUploadResult.setUploadId("uploadId");
-
-        Mockito.doReturn(initiateMultipartUploadResult).when(spyClient).initiateMultipartUpload(
-                Mockito.argThat(argument ->
-                        argument.getBucketName().equals(S3_TEST_BUCKET) &&
-                        argument.getKey().equals("/success/object"))
-        );
-
-        CopyPartResult copyPartResult = new CopyPartResult();
-        copyPartResult.setETag("copy-part-etag");
-
-        Mockito.doReturn(copyPartResult).when(spyClient).copyPart(
-                Mockito.argThat(argument ->
-                        argument.getUploadId().equals("uploadId") &&
-                        argument.getSourceBucketName().equals(S3_TEST_BUCKET) &&
-                        argument.getSourceKey().equals(S3_OBJECT_KEY) &&
-                        argument.getDestinationBucketName().equals(S3_TEST_BUCKET) &&
-                        argument.getDestinationKey().equals("/success/object")
-                )
-        );
-
-        CompleteMultipartUploadResult completeMultipartUploadResult = new CompleteMultipartUploadResult();
-        completeMultipartUploadResult.setETag("complete-upload-etag");
-
-        Mockito.doReturn(completeMultipartUploadResult).when(spyClient).completeMultipartUpload(
-                Mockito.argThat(argument ->
-                        argument.getBucketName().equals(S3_TEST_BUCKET) &&
-                        argument.getKey().equals("/success/object") &&
-                        argument.getUploadId().equals("uploadId") &&
-                        argument.getPartETags().size() == 62
-                )
-        );
-
-        AmazonS3Storage bigStorage = new AmazonS3Storage(spyClient);
-        bigStorage.configure(new HashMap<>());
-
-        var cleaner = new AmazonS3MoveCleanupPolicy();
-        cleaner.setStorage(bigStorage);
-        cleaner.configure(Map.of(
-                AmazonS3MoveCleanupPolicy.Config.SUCCESS_AWS_PREFIX_PATH_CONFIG, "/success/",
-                AmazonS3MoveCleanupPolicy.Config.FAILURES_AWS_PREFIX_PATH_CONFIG, "/failure/"
-        ));
-
-        // WHEN
-        FileObjectMeta objectMetadata = storage.getObjectMetadata(new S3BucketKey(S3_TEST_BUCKET, S3_OBJECT_KEY));
-        cleaner.onSuccess(
-                new FileObject(
-                        objectMetadata,
-                        FileObjectOffset.empty(),
-                        FileObjectStatus.COMPLETED
-                )
-        );
-
-        // THEN
-        Mockito.verify(spyClient, Mockito.times(1)).initiateMultipartUpload(
-                Mockito.argThat(argument ->
-                        argument.getBucketName().equals(S3_TEST_BUCKET) &&
-                        argument.getKey().equals("/success/object")
-                )
-        );
-        Mockito.verify(spyClient, Mockito.times(62)).copyPart(
-                Mockito.argThat(argument ->
-                        argument.getUploadId().equals("uploadId") &&
-                        argument.getSourceBucketName().equals(S3_TEST_BUCKET) &&
-                        argument.getSourceKey().equals(S3_OBJECT_KEY) &&
-                        argument.getDestinationBucketName().equals(S3_TEST_BUCKET) &&
-                        argument.getDestinationKey().equals("/success/object")
-                )
-        );
-        Mockito.verify(spyClient, Mockito.times(1)).completeMultipartUpload(
-                Mockito.argThat(argument ->
-                        argument.getBucketName().equals(S3_TEST_BUCKET) &&
-                        argument.getKey().equals("/success/object") &&
-                        argument.getUploadId().equals("uploadId") &&
-                        argument.getPartETags().size() == 62
-                )
-        );
     }
 
     @Test

--- a/connect-file-pulse-plugin/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/DefaultFileSystemMonitor.java
+++ b/connect-file-pulse-plugin/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/DefaultFileSystemMonitor.java
@@ -461,6 +461,7 @@ public class DefaultFileSystemMonitor implements FileSystemMonitor {
                 LOG.info("Closing FileSystemMonitor resources");
                 readStatesToEnd(stateDefaultReadTimeout);
                 cleanUpCompletedFiles();
+                this.fsListing.close();
                 LOG.info("Closed FileSystemMonitor resources");
             } catch (final Exception e) {
                 LOG.warn("Unexpected error while closing FileSystemMonitor.", e);


### PR DESCRIPTION
switch to multipart copy when cleaning up files bigger than the AWS S3 SDK copy operation size limit of 5 GB that would otherwise fail