### PR TITLE
fix(filters): remove usage of ConfigUtils.translateDeprecatedConfigs

### DIFF
--- a/connect-file-pulse-filters/src/main/java/io/streamthoughts/kafka/connect/filepulse/config/CommonFilterConfig.java
+++ b/connect-file-pulse-filters/src/main/java/io/streamthoughts/kafka/connect/filepulse/config/CommonFilterConfig.java
@@ -14,6 +14,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 
@@ -66,6 +67,44 @@ public class CommonFilterConfig extends AbstractConfig {
      */
     public CommonFilterConfig(final ConfigDef def, final Map<?, ?> originals, final boolean doLog) {
         super(def, originals, doLog);
+    }
+
+    /**
+     * Translates deprecated aliases to their new config keys.
+     *
+     * @param originals   the original configs.
+     * @param aliasGroups map where key is canonical config and value is deprecated aliases.
+     * @return a translated copy of the original configs.
+     */
+    public static Map<String, Object> translateDeprecatedConfigs(final Map<String, ?> originals,
+                                                                 final Map<String, List<String>> aliasGroups) {
+        final Set<String> aliasSet = new HashSet<>();
+        aliasSet.addAll(aliasGroups.keySet());
+        aliasSet.addAll(aliasGroups.values().stream().flatMap(List::stream).collect(Collectors.toSet()));
+
+        // Keep only non-alias keys from the original map.
+        final Map<String, Object> translatedConfigs = originals.entrySet().stream()
+                .filter(entry -> !aliasSet.contains(entry.getKey()))
+                .filter(entry -> entry.getValue() != null)
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        for (Map.Entry<String, List<String>> aliasGroup : aliasGroups.entrySet()) {
+            final String config = aliasGroup.getKey();
+            final List<String> aliases = aliasGroup.getValue().stream()
+                    .filter(originals::containsKey)
+                    .collect(Collectors.toList());
+
+            if (aliases.isEmpty()) {
+                if (originals.containsKey(config) && originals.get(config) != null) {
+                    translatedConfigs.put(config, originals.get(config));
+                }
+                continue;
+            }
+
+            // Alias takes precedence to handle maps where defaults pre-fill target keys.
+            translatedConfigs.put(config, originals.get(aliases.get(0)));
+        }
+        return translatedConfigs;
     }
 
     public FilterCondition condition() {

--- a/connect-file-pulse-filters/src/main/java/io/streamthoughts/kafka/connect/filepulse/config/DelimitedRowFilterConfig.java
+++ b/connect-file-pulse-filters/src/main/java/io/streamthoughts/kafka/connect/filepulse/config/DelimitedRowFilterConfig.java
@@ -10,11 +10,11 @@ import io.streamthoughts.kafka.connect.filepulse.data.Schema;
 import io.streamthoughts.kafka.connect.filepulse.data.StructSchema;
 import io.streamthoughts.kafka.connect.filepulse.data.Type;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
-import org.apache.kafka.common.utils.ConfigUtils;
 
 public class DelimitedRowFilterConfig extends CommonFilterConfig {
 
@@ -59,12 +59,12 @@ public class DelimitedRowFilterConfig extends CommonFilterConfig {
                                     final Map<String, ?> originals) {
         super(
             configDef,
-            ConfigUtils.translateDeprecatedConfigs(originals, new String[][]{
-                    {READER_FIELD_TRIM_COLUMN_CONFIG, READER_FIELD_TRIM_COLUMN_CONFIG_ALIAS},
-                    {READER_FIELD_DUPLICATE_COLUMNS_AS_ARRAY_CONFIG, READER_FIELD_DUPLICATE_COLUMNS_AS_ARRAY_CONFIG_ALIAS},
-                    {READER_EXTRACT_COLUMN_NAME_CONFIG, READER_EXTRACT_COLUMN_NAME_CONFIG_ALIAS},
-                    {READER_AUTO_GENERATE_COLUMN_NAME_CONFIG, READER_AUTO_GENERATE_COLUMN_NAME_CONFIG_ALIAS},
-            })
+            CommonFilterConfig.translateDeprecatedConfigs(originals, Map.of(
+                    READER_FIELD_TRIM_COLUMN_CONFIG, List.of(READER_FIELD_TRIM_COLUMN_CONFIG_ALIAS),
+                    READER_FIELD_DUPLICATE_COLUMNS_AS_ARRAY_CONFIG, List.of(READER_FIELD_DUPLICATE_COLUMNS_AS_ARRAY_CONFIG_ALIAS),
+                    READER_EXTRACT_COLUMN_NAME_CONFIG, List.of(READER_EXTRACT_COLUMN_NAME_CONFIG_ALIAS),
+                    READER_AUTO_GENERATE_COLUMN_NAME_CONFIG, List.of(READER_AUTO_GENERATE_COLUMN_NAME_CONFIG_ALIAS)
+            ))
         );
     }
 

--- a/connect-file-pulse-filters/src/main/java/io/streamthoughts/kafka/connect/filepulse/filter/DelimitedRowFilter.java
+++ b/connect-file-pulse-filters/src/main/java/io/streamthoughts/kafka/connect/filepulse/filter/DelimitedRowFilter.java
@@ -6,11 +6,12 @@
  */
 package io.streamthoughts.kafka.connect.filepulse.filter;
 
+import io.streamthoughts.kafka.connect.filepulse.config.CommonFilterConfig;
 import io.streamthoughts.kafka.connect.filepulse.internal.StringUtils;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.common.utils.ConfigUtils;
 
 public class DelimitedRowFilter extends AbstractDelimitedRowFilter<DelimitedRowFilter> {
 
@@ -30,9 +31,9 @@ public class DelimitedRowFilter extends AbstractDelimitedRowFilter<DelimitedRowF
      */
     @Override
     public void configure(final Map<String, ?> configs) {
-        super.configure(ConfigUtils.translateDeprecatedConfigs(configs, new String[][]{
-                {READER_FIELD_SEPARATOR_CONFIG, READER_FIELD_SEPARATOR_CONFIG_ALIAS}
-        }));
+        final Map<String, Object> translatedConfigs = CommonFilterConfig.translateDeprecatedConfigs(configs,
+                Map.of(READER_FIELD_SEPARATOR_CONFIG, List.of(READER_FIELD_SEPARATOR_CONFIG_ALIAS)));
+        super.configure(translatedConfigs);
 
         delimiter = filterConfig().getString(READER_FIELD_SEPARATOR_CONFIG);
 

--- a/connect-file-pulse-filters/src/test/java/io/streamthoughts/kafka/connect/filepulse/config/DelimitedRowFilterConfigTest.java
+++ b/connect-file-pulse-filters/src/test/java/io/streamthoughts/kafka/connect/filepulse/config/DelimitedRowFilterConfigTest.java
@@ -6,10 +6,15 @@
  */
 package io.streamthoughts.kafka.connect.filepulse.config;
 
+import static io.streamthoughts.kafka.connect.filepulse.config.DelimitedRowFilterConfig.READER_AUTO_GENERATE_COLUMN_NAME_CONFIG_ALIAS;
 import static io.streamthoughts.kafka.connect.filepulse.config.DelimitedRowFilterConfig.READER_AUTO_GENERATE_COLUMN_NAME_DEFAULT;
 import static io.streamthoughts.kafka.connect.filepulse.config.DelimitedRowFilterConfig.READER_EXTRACT_COLUMN_NAME_CONFIG;
+import static io.streamthoughts.kafka.connect.filepulse.config.DelimitedRowFilterConfig.READER_EXTRACT_COLUMN_NAME_CONFIG_ALIAS;
 import static io.streamthoughts.kafka.connect.filepulse.config.DelimitedRowFilterConfig.READER_FIELD_COLUMNS_CONFIG;
+import static io.streamthoughts.kafka.connect.filepulse.config.DelimitedRowFilterConfig.READER_FIELD_DUPLICATE_COLUMNS_AS_ARRAY_CONFIG;
+import static io.streamthoughts.kafka.connect.filepulse.config.DelimitedRowFilterConfig.READER_FIELD_DUPLICATE_COLUMNS_AS_ARRAY_CONFIG_ALIAS;
 import static io.streamthoughts.kafka.connect.filepulse.config.DelimitedRowFilterConfig.READER_FIELD_TRIM_COLUMN_CONFIG;
+import static io.streamthoughts.kafka.connect.filepulse.config.DelimitedRowFilterConfig.READER_FIELD_TRIM_COLUMN_CONFIG_ALIAS;
 import static io.streamthoughts.kafka.connect.filepulse.config.DelimitedRowFilterConfig.READER_FIELD_TRIM_COLUMN_DEFAULT;
 import static io.streamthoughts.kafka.connect.filepulse.filter.DelimitedRowFilter.READER_FIELD_SEPARATOR_CONFIG;
 import static io.streamthoughts.kafka.connect.filepulse.filter.DelimitedRowFilter.READER_FIELD_SEPARATOR_DEFAULT;
@@ -55,6 +60,51 @@ public class DelimitedRowFilterConfigTest {
     }
 
     @Test
+    public void shouldHonourDeprecatedAliasEvenWhenNewKeyHasDefault() {
+        // Reproduces the bug: when a framework pre-fills new key with its ConfigDef default (false),
+        // the deprecated alias (trimColumn=true) must still take effect.
+        Map<String, Object> props = new HashMap<>() {{
+            put(READER_FIELD_TRIM_COLUMN_CONFIG, false);           // default pre-filled by framework
+            put(READER_FIELD_TRIM_COLUMN_CONFIG_ALIAS, true);      // user explicitly set deprecated alias
+            put(READER_AUTO_GENERATE_COLUMN_NAME_CONFIG_ALIAS, true);
+        }};
+
+        Map<String, Object> translated = CommonFilterConfig.translateDeprecatedConfigs(props, deprecatedAliasGroups());
+        Assert.assertFalse("Deprecated alias key must not remain in translated config map",
+                translated.containsKey(READER_FIELD_TRIM_COLUMN_CONFIG_ALIAS));
+        Assert.assertEquals(true, translated.get(READER_FIELD_TRIM_COLUMN_CONFIG));
+
+        DelimitedRowFilterConfig config = new DelimitedRowFilterConfig(filter.configDef(), props);
+
+        Assert.assertTrue("Deprecated alias trimColumn=true must override the pre-filled default trim.column=false",
+                config.isTrimColumn());
+    }
+
+    @Test
+    public void shouldRemoveDeprecatedAliasesFromTranslatedConfigMap() {
+        Map<String, Object> props = new HashMap<>() {{
+            put(READER_FIELD_TRIM_COLUMN_CONFIG_ALIAS, true);
+            put(READER_FIELD_DUPLICATE_COLUMNS_AS_ARRAY_CONFIG_ALIAS, true);
+            put(READER_EXTRACT_COLUMN_NAME_CONFIG_ALIAS, "header");
+            put(READER_AUTO_GENERATE_COLUMN_NAME_CONFIG_ALIAS, false);
+            put("custom.config", "custom-value");
+        }};
+
+        Map<String, Object> translated = CommonFilterConfig.translateDeprecatedConfigs(props, deprecatedAliasGroups());
+
+        Assert.assertFalse(translated.containsKey(READER_FIELD_TRIM_COLUMN_CONFIG_ALIAS));
+        Assert.assertFalse(translated.containsKey(READER_FIELD_DUPLICATE_COLUMNS_AS_ARRAY_CONFIG_ALIAS));
+        Assert.assertFalse(translated.containsKey(READER_EXTRACT_COLUMN_NAME_CONFIG_ALIAS));
+        Assert.assertFalse(translated.containsKey(READER_AUTO_GENERATE_COLUMN_NAME_CONFIG_ALIAS));
+
+        Assert.assertEquals(true, translated.get(READER_FIELD_TRIM_COLUMN_CONFIG));
+        Assert.assertEquals(true, translated.get(READER_FIELD_DUPLICATE_COLUMNS_AS_ARRAY_CONFIG));
+        Assert.assertEquals("header", translated.get(READER_EXTRACT_COLUMN_NAME_CONFIG));
+        Assert.assertEquals(false, translated.get(DelimitedRowFilterConfig.READER_AUTO_GENERATE_COLUMN_NAME_CONFIG));
+        Assert.assertEquals("custom-value", translated.get("custom.config"));
+    }
+
+    @Test
     public void shouldCreateConfigGivenSchema() {
 
         Map<String, String> props = new HashMap<>() {{
@@ -81,6 +131,15 @@ public class DelimitedRowFilterConfigTest {
         Assert.assertEquals("x1", fieldsByIndex.get(0).name());
         Assert.assertEquals("c2", fieldsByIndex.get(1).name());
         Assert.assertEquals("y3", fieldsByIndex.get(2).name());
+    }
+
+    private static Map<String, List<String>> deprecatedAliasGroups() {
+        return Map.of(
+                READER_FIELD_TRIM_COLUMN_CONFIG, List.of(READER_FIELD_TRIM_COLUMN_CONFIG_ALIAS),
+                READER_FIELD_DUPLICATE_COLUMNS_AS_ARRAY_CONFIG, List.of(READER_FIELD_DUPLICATE_COLUMNS_AS_ARRAY_CONFIG_ALIAS),
+                READER_EXTRACT_COLUMN_NAME_CONFIG, List.of(READER_EXTRACT_COLUMN_NAME_CONFIG_ALIAS),
+                DelimitedRowFilterConfig.READER_AUTO_GENERATE_COLUMN_NAME_CONFIG, List.of(READER_AUTO_GENERATE_COLUMN_NAME_CONFIG_ALIAS)
+        );
     }
 
 }

--- a/docs/content/en/docs/Developer Guide/filters.md
+++ b/docs/content/en/docs/Developer Guide/filters.md
@@ -80,7 +80,7 @@ filters.SubstituteFilter.value="{{ extract_array($.values,0) }}-{{ extract_array
       "World"
     ]
   }
-} 
+}
 ```
 
 **Output**
@@ -124,7 +124,7 @@ filters.SubstituteFilter.value="my-topic-{{ lowercase(extract_array($.values,0))
       "World"
     ]
   }
-} 
+}
 ```
 
 **Output**
@@ -140,7 +140,7 @@ filters.SubstituteFilter.value="my-topic-{{ lowercase(extract_array($.values,0))
       "World"
     ]
   }
-} 
+}
 ```
 
 Finally, the `AppendFilter` can also accept a substitution expression for the property field.
@@ -333,22 +333,22 @@ Each row is parsed and published into a configured topic as a single Kafka data.
 
 | Configuration       | Description                                                                                                         | Type    | Default | Importance |
 |---------------------|---------------------------------------------------------------------------------------------------------------------|---------|---------|------------|
-| `separator`         | The character used as a delimiter/separator between each value                                                      | string  | *;*     | high       |
-| `trimColumn`        | Remove the leading and trailing whitespaces from all columns.                                                       | boolean | *false* | low        |
-| `extractColumnName` | Define the field from which the schema should be detected (all columns will be of type 'string')                    | string  |         | high       |
+| `regex`             | The delimiter regex used to split each value (deprecated alias: `separator`)                                        | string  | *;*     | high       |
+| `trim.column`       | Remove the leading and trailing whitespaces from all columns (deprecated alias: `trimColumn`).                     | boolean | *false* | low        |
+| `extract.column.name` | Define the field from which the schema should be detected (all columns will be of type 'string') (deprecated alias: `extractColumnName`). | string  |         | high       |
 | `columns`           | The list of comma-separated column names in order they appear in each row. columns must be in the form of NAME:TYPE | string  |         | high       |
 
 ### Examples
 
-The following example shows the use of the `DelimitedRowFilter` to split the `message` field using `|` as a separator
+The following example shows the use of the `DelimitedRowFilter` to split the `message` field using `|` as a delimiter
 character.
 The name of each column is extracted from the fields `headers`.
 
 ```properties
 filters=ParseDelimitedRow
-filters.ParseDelimitedRow.extractColumnNam="headers"
-filters.ParseDelimitedRow.separator="\\|"
-filters.ParseDelimitedRow.trimColumn="true"
+filters.ParseDelimitedRow.extract.column.name="headers"
+filters.ParseDelimitedRow.regex="\\|"
+filters.ParseDelimitedRow.trim.column="true"
 filters.ParseDelimitedRow.type="io.streamthoughts.kafka.connect.filepulse.filter.DelimitedRowFilter"
 ```
 
@@ -1015,7 +1015,7 @@ The `XmlToStructFilter` parses an XML record-field into STRUCT
 | Configuration                                 | Since | Description                                                                                                                           | Type      | Default     | Importance |
 |-----------------------------------------------|-------|---------------------------------------------------------------------------------------------------------------------------------------|-----------|-------------|------------|
 | `source`                                      |       | The input field on which to apply the filter.                                                                                         | string    | `"message"` | High       |
-| `xml.force.array.on.fields`                   |       | The comma-separated list of fields for which an array-type must be forced                                                             | `List`    |             | High       |                                                
+| `xml.force.array.on.fields`                   |       | The comma-separated list of fields for which an array-type must be forced                                                             | `List`    |             | High       |
 | `xml.parser.validating.enabled`               |       | Specifies that the parser will validate documents as they are parsed.                                                                 | `boolean` | `false`     | Low        |
 | `xml.parser.namespace.aware.enabled`          |       | Specifies that the XML parser will provide support for XML namespaces.                                                                | `boolean` | `false`     | Low        |
 | `xml.exclude.empty.elements`                  |       | Specifies that the reader should exclude element having no field.                                                                     | `boolean` | `false`     | Low        |


### PR DESCRIPTION
Fix #745

This PR removes dependency on `ConfigUtils.translateDeprecatedConfigs` (removed in Kafka 4) and replaces it with local, reusable deprecated-config translation logic in File Pulse filters.

## What changed

- Replaced deprecated config translation usage with local implementation compatible with Kafka 4.
- Introduced a shared helper in `CommonFilterConfig`:
  - `translateDeprecatedConfigs(Map<String, ?> originals, Map<String, List<String>> aliasGroups)`
- Kept backward compatibility for deprecated keys (e.g. `separator` -> `regex`, `trimColumn` -> `trim.column`, etc.).

## Behavior fix included

- Fixed edge case where deprecated aliases could be ignored when canonical keys were pre-filled with default values (e.g. `trim.column=false` default + `trimColumn=true` explicitly set).
- In this scenario, explicit deprecated alias value is now correctly applied to the canonical key.

## Tests

- Extended `DelimitedRowFilterConfigTest` with regression coverage for:
  - deprecated alias overriding pre-filled default (`trimColumn` case)
  - alias cleanup (deprecated keys not present after translation)
- Existing `DelimitedRowFilterTest` and updated config tests pass.

## Docs

- Updated docs/config wording to point users to canonical config names (deprecated aliases remain supported for backward compatibility).